### PR TITLE
Remove `twIdiom` since its unnecessary for lyrics

### DIFF
--- a/LyricsX/Component/ChineseConverter+Singleton.swift
+++ b/LyricsX/Component/ChineseConverter+Singleton.swift
@@ -22,7 +22,7 @@ extension ChineseConverter {
         switch change.newValue {
         case 1: ChineseConverter._shared = try? ChineseConverter(options: [.simplify])
         case 2: ChineseConverter._shared = try? ChineseConverter(options: [.traditionalize])
-        case 3: ChineseConverter._shared = try? ChineseConverter(options: [.traditionalize, .twStandard, .twIdiom])
+        case 3: ChineseConverter._shared = try? ChineseConverter(options: [.traditionalize, .twStandard])
         case 4: ChineseConverter._shared = try? ChineseConverter(options: [.traditionalize, .hkStandard])
         case 0, _: ChineseConverter._shared = nil
         }


### PR DESCRIPTION
发现这个设定会把用词整个改掉，歌词不应该套用