### PR TITLE
feat: add a new `lyrics source` tab and priority ranking function

### DIFF
--- a/LyricsX.xcodeproj/project.pbxproj
+++ b/LyricsX.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		0F07BAF52E8A8B2900085912 /* PreferenceSourceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F07BAF42E8A8B2900085912 /* PreferenceSourceViewController.swift */; };
 		BB03C8891FDF6FC000FBE0DA /* ChineseConverter+Singleton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB03C8881FDF6FC000FBE0DA /* ChineseConverter+Singleton.swift */; };
 		BB063B2E1E8A93C900A25C3E /* KaraokeLyricsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB063B2D1E8A93C900A25C3E /* KaraokeLyricsView.swift */; };
 		BB0B296A1E7FBA2D00B1D6C9 /* PreferenceFilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB0B29691E7FBA2D00B1D6C9 /* PreferenceFilterViewController.swift */; };
@@ -112,6 +113,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0F07BAF42E8A8B2900085912 /* PreferenceSourceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferenceSourceViewController.swift; sourceTree = "<group>"; };
 		BB03C8881FDF6FC000FBE0DA /* ChineseConverter+Singleton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChineseConverter+Singleton.swift"; sourceTree = "<group>"; };
 		BB063B2D1E8A93C900A25C3E /* KaraokeLyricsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KaraokeLyricsView.swift; sourceTree = "<group>"; };
 		BB0B29691E7FBA2D00B1D6C9 /* PreferenceFilterViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferenceFilterViewController.swift; sourceTree = "<group>"; };
@@ -318,6 +320,7 @@
 		BBC7C5561E6AEA4500E3EC4F /* Preferences */ = {
 			isa = PBXGroup;
 			children = (
+				0F07BAF42E8A8B2900085912 /* PreferenceSourceViewController.swift */,
 				E975C5BA2D380B920059BE92 /* PreferenceWindowController.swift */,
 				E91F76EA21211B8D00755698 /* PreferenceViewController.swift */,
 				BBC7C5541E6AE28600E3EC4F /* PreferenceGeneralViewController.swift */,
@@ -718,6 +721,7 @@
 				BBE2A79824041E36004A7E93 /* CombineExtension.swift in Sources */,
 				BBC1D35B1E485BA7002538A2 /* AppController.swift in Sources */,
 				BB0B296A1E7FBA2D00B1D6C9 /* PreferenceFilterViewController.swift in Sources */,
+				0F07BAF52E8A8B2900085912 /* PreferenceSourceViewController.swift in Sources */,
 				BB89089E21ED69410078F522 /* Lyrics+Language.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/LyricsX/Base.lproj/Preferences.storyboard
+++ b/LyricsX/Base.lproj/Preferences.storyboard
@@ -37,6 +37,7 @@
                         <tabViewItem image="toolbar_shortcut" id="MZ9-ON-TxW" userLabel="Shortcut"/>
                         <tabViewItem image="toolbar_filter" id="xcA-tm-q8A" userLabel="Filter"/>
                         <tabViewItem image="toolbar_lab" id="Vr0-wO-OTg" userLabel="Lab"/>
+                        <tabViewItem image="list.bullet" catalog="system" id="YeP-CD-LQP" userLabel="Source"/>
                     </tabViewItems>
                     <viewControllerTransitionOptions key="transitionOptions"/>
                     <tabView key="tabView" type="noTabsNoBorder" id="ufX-Bl-B8D">
@@ -54,6 +55,7 @@
                         <segue destination="1GH-DC-cpo" kind="relationship" relationship="tabItems" id="MY0-FE-Tv6"/>
                         <segue destination="lN1-gG-AVq" kind="relationship" relationship="tabItems" id="wPI-VX-th7"/>
                         <segue destination="JPs-hn-m7d" kind="relationship" relationship="tabItems" id="1hg-lI-T8Z"/>
+                        <segue destination="KTZ-mJ-lpY" kind="relationship" relationship="tabItems" id="rJ8-Fp-eFJ"/>
                     </connections>
                 </tabViewController>
                 <customObject id="n2u-iM-pje" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
@@ -2556,6 +2558,169 @@
             </objects>
             <point key="canvasLocation" x="1977" y="1393"/>
         </scene>
+        <!--Source-->
+        <scene sceneID="CzA-mO-0w8">
+            <objects>
+                <viewController title="Source" id="KTZ-mJ-lpY" customClass="PreferenceSourceViewController" customModule="LyricsX" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" misplaced="YES" id="Bkt-jy-GD5">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="248"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <subviews>
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="eMr-xF-JY5">
+                                <rect key="frame" x="18" y="190" width="369" height="12"/>
+                                <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Drag rows to reorder source priority. If disabled, it will be sorted by quality." id="e8O-oC-igZ">
+                                    <font key="font" size="11" name="HelveticaNeue"/>
+                                    <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <scrollView autohidesScrollers="YES" horizontalLineScroll="24" horizontalPageScroll="10" verticalLineScroll="24" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TcY-l7-0hN">
+                                <rect key="frame" x="20" y="24" width="560" height="150"/>
+                                <clipView key="contentView" id="dVG-81-AoX">
+                                    <rect key="frame" x="1" y="1" width="558" height="148"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="24" rowSizeStyle="automatic" headerView="Kzd-3h-xxb" viewBased="YES" id="gXu-L7-amu">
+                                            <rect key="frame" x="0.0" y="0.0" width="558" height="120"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <size key="intercellSpacing" width="17" height="0.0"/>
+                                            <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
+                                            <tableColumns>
+                                                <tableColumn identifier="priority" width="50" minWidth="40" maxWidth="1000" id="Vdv-QC-53v">
+                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="Priority">
+                                                        <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                    </tableHeaderCell>
+                                                    <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" title="Text Cell" id="Jrh-7d-oXZ">
+                                                        <font key="font" metaFont="system"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                    <prototypeCellViews>
+                                                        <tableCellView id="eDu-g5-88j">
+                                                            <rect key="frame" x="8" y="0.0" width="48" height="24"/>
+                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                            <subviews>
+                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="9IN-Vb-1XD">
+                                                                    <rect key="frame" x="0.0" y="4" width="48" height="16"/>
+                                                                    <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" id="Vm6-Kh-M3U">
+                                                                        <font key="font" usesAppearanceFont="YES"/>
+                                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                            </subviews>
+                                                            <constraints>
+                                                                <constraint firstItem="9IN-Vb-1XD" firstAttribute="centerY" secondItem="eDu-g5-88j" secondAttribute="centerY" id="CVG-tK-w3M"/>
+                                                                <constraint firstItem="9IN-Vb-1XD" firstAttribute="leading" secondItem="eDu-g5-88j" secondAttribute="leading" constant="2" id="M6r-Dp-wIH"/>
+                                                                <constraint firstItem="9IN-Vb-1XD" firstAttribute="centerX" secondItem="eDu-g5-88j" secondAttribute="centerX" id="o2w-JI-vb4"/>
+                                                            </constraints>
+                                                            <connections>
+                                                                <outlet property="textField" destination="9IN-Vb-1XD" id="Aro-T9-jz8"/>
+                                                            </connections>
+                                                        </tableCellView>
+                                                    </prototypeCellViews>
+                                                </tableColumn>
+                                                <tableColumn identifier="source" width="479" minWidth="40" maxWidth="1000" id="xXN-7W-SKY">
+                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="Source">
+                                                        <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                    </tableHeaderCell>
+                                                    <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" title="Text Cell" id="2Oq-HQ-Eas">
+                                                        <font key="font" metaFont="system"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                    <prototypeCellViews>
+                                                        <tableCellView id="VGV-SG-dwt">
+                                                            <rect key="frame" x="73" y="0.0" width="476" height="24"/>
+                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                            <subviews>
+                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="KUU-qx-NSS">
+                                                                    <rect key="frame" x="0.0" y="4" width="476" height="16"/>
+                                                                    <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" id="ow1-De-Qmh">
+                                                                        <font key="font" usesAppearanceFont="YES"/>
+                                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                            </subviews>
+                                                            <constraints>
+                                                                <constraint firstItem="KUU-qx-NSS" firstAttribute="centerX" secondItem="VGV-SG-dwt" secondAttribute="centerX" id="NMs-Q3-xPA"/>
+                                                                <constraint firstItem="KUU-qx-NSS" firstAttribute="centerY" secondItem="VGV-SG-dwt" secondAttribute="centerY" id="Sks-8o-ygB"/>
+                                                                <constraint firstItem="KUU-qx-NSS" firstAttribute="leading" secondItem="VGV-SG-dwt" secondAttribute="leading" constant="2" id="jR1-vK-IqN"/>
+                                                            </constraints>
+                                                            <connections>
+                                                                <outlet property="textField" destination="KUU-qx-NSS" id="hjI-d9-h8D"/>
+                                                            </connections>
+                                                        </tableCellView>
+                                                    </prototypeCellViews>
+                                                </tableColumn>
+                                            </tableColumns>
+                                            <connections>
+                                                <outlet property="dataSource" destination="KTZ-mJ-lpY" id="7fM-ei-hnA"/>
+                                                <outlet property="delegate" destination="KTZ-mJ-lpY" id="pfO-lP-pDY"/>
+                                            </connections>
+                                        </tableView>
+                                    </subviews>
+                                </clipView>
+                                <constraints>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="160" id="UVZ-8W-DFG"/>
+                                    <constraint firstAttribute="height" relation="lessThanOrEqual" constant="300" id="iOL-7T-LTy"/>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="150" id="z0H-bo-IFm"/>
+                                </constraints>
+                                <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="Cq9-fY-Mad">
+                                    <rect key="frame" x="1" y="184" width="158" height="15"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </scroller>
+                                <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="Vnq-hy-YBN">
+                                    <rect key="frame" x="224" y="17" width="15" height="102"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </scroller>
+                                <tableHeaderView key="headerView" wantsLayer="YES" id="Kzd-3h-xxb">
+                                    <rect key="frame" x="0.0" y="0.0" width="558" height="28"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </tableHeaderView>
+                            </scrollView>
+                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Rs6-hk-kzP">
+                                <rect key="frame" x="18" y="209" width="207" height="16"/>
+                                <buttonCell key="cell" type="check" title="Enable source priority ranking" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="au8-ou-Duf">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="14" id="bxP-rt-bwh"/>
+                                </constraints>
+                                <connections>
+                                    <action selector="toggleSourcePriority:" target="KTZ-mJ-lpY" id="3S7-On-Gfb"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="TcY-l7-0hN" firstAttribute="leading" secondItem="Bkt-jy-GD5" secondAttribute="leading" constant="20" id="0Sk-4v-jVW"/>
+                            <constraint firstItem="Rs6-hk-kzP" firstAttribute="leading" secondItem="Bkt-jy-GD5" secondAttribute="leading" constant="20" id="2cw-DD-lDi"/>
+                            <constraint firstAttribute="trailing" secondItem="TcY-l7-0hN" secondAttribute="trailing" constant="20" id="2mo-Nh-pkR"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Rs6-hk-kzP" secondAttribute="trailing" constant="20" id="7B9-GI-7yz"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="eMr-xF-JY5" secondAttribute="trailing" constant="20" id="Nvu-Eg-xwe"/>
+                            <constraint firstAttribute="bottom" secondItem="TcY-l7-0hN" secondAttribute="bottom" constant="24" id="Q5D-XX-2sF"/>
+                            <constraint firstItem="eMr-xF-JY5" firstAttribute="top" secondItem="Rs6-hk-kzP" secondAttribute="bottom" constant="8" id="hYH-P6-g1p"/>
+                            <constraint firstItem="eMr-xF-JY5" firstAttribute="leading" secondItem="Rs6-hk-kzP" secondAttribute="leading" id="op1-11-sKa"/>
+                            <constraint firstItem="TcY-l7-0hN" firstAttribute="top" secondItem="eMr-xF-JY5" secondAttribute="bottom" constant="16" id="qK9-My-pei"/>
+                            <constraint firstItem="Rs6-hk-kzP" firstAttribute="top" secondItem="Bkt-jy-GD5" secondAttribute="top" constant="24" id="ztn-mE-wra"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="enableSourcePriorityButton" destination="Rs6-hk-kzP" id="kuj-nf-VT6"/>
+                        <outlet property="sourceTableView" destination="gXu-L7-amu" id="hq1-0v-D7c"/>
+                    </connections>
+                </viewController>
+                <customObject id="JkS-yT-8ul" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1969" y="1868"/>
+        </scene>
     </scenes>
     <resources>
         <image name="NSAddTemplate" width="18" height="17"/>
@@ -2566,6 +2731,7 @@
         <image name="audirvana_icon" width="64" height="64"/>
         <image name="folder" width="21" height="18"/>
         <image name="iTunes_icon" width="64" height="64"/>
+        <image name="list.bullet" catalog="system" width="16" height="12"/>
         <image name="now_playing_icon" width="64" height="64"/>
         <image name="spotify_icon" width="64" height="64"/>
         <image name="swinsian_icon" width="64" height="64"/>

--- a/LyricsX/Component/AppController.swift
+++ b/LyricsX/Component/AppController.swift
@@ -234,14 +234,37 @@ class AppController: NSObject {
         if defaults[.strictSearchEnabled] && !lyrics.isMatched() {
             return
         }
-        if let current = currentLyrics, current.quality >= lyrics.quality {
-            return
+        if let current = currentLyrics {
+            let shouldReplace = shouldReplaceLyrics(current: current, new: lyrics)
+            if !shouldReplace {
+                return
+            }
         }
+        
         lyrics.associateWithTrack(track)
         lyrics.filtrate()
         lyrics.recognizeLanguage()
         lyrics.metadata.needsPersist = true
         currentLyrics = lyrics
+    }
+    
+    private func shouldReplaceLyrics(current: Lyrics, new: Lyrics) -> Bool {
+        // If source priority is enabled, use it for comparison
+        if defaults[.lyricsSourcePriorityEnabled] {
+            let sourceOrder = defaults[.lyricsSourcePriorityOrder] ?? []
+            let currentSource = current.metadata.service ?? ""
+            let newSource = new.metadata.service ?? ""
+            
+            let currentSourceIndex = sourceOrder.firstIndex(of: currentSource) ?? Int.max
+            let newSourceIndex = sourceOrder.firstIndex(of: newSource) ?? Int.max
+            
+            if currentSourceIndex != newSourceIndex {
+                return newSourceIndex < currentSourceIndex
+            }
+        }
+        
+        // Use quality for comparison if priorities are the same or disabled
+        return new.quality > current.quality
     }
 }
 

--- a/LyricsX/Preferences/PreferenceSourceViewController.swift
+++ b/LyricsX/Preferences/PreferenceSourceViewController.swift
@@ -1,0 +1,135 @@
+//
+//  PreferenceSourceViewController.swift
+//  LyricsX
+//
+//  Created by Gol3vka on 2025/9/29.
+//  Copyright © 2025 ddddxxx. All rights reserved.
+//
+
+import Cocoa
+import LyricsXFoundation
+
+class PreferenceSourceViewController: PreferenceViewController {
+    
+    @IBOutlet weak var enableSourcePriorityButton: NSButton!
+    @IBOutlet weak var sourceTableView: NSTableView!
+    
+    private var availableSources: [String] = []
+    private var sourcePriorityOrder: [String] = []
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        // Match the source list defined in LyricsKit, alphabetically sorted
+        // TODO: fetch from LyricsKit dynamically if possible
+        availableSources = [
+            "Kugou",
+            "LRCLIB",
+            "NetEase",
+            "QQMusic",
+            "Spotify"
+        ]
+        
+        enableSourcePriorityButton.state = defaults[.lyricsSourcePriorityEnabled] ? .on : .off
+        sourcePriorityOrder = defaults[.lyricsSourcePriorityOrder] ?? availableSources
+        for source in availableSources {
+            if !sourcePriorityOrder.contains(source) {
+                sourcePriorityOrder.append(source)
+            }
+        }
+        sourcePriorityOrder = sourcePriorityOrder.filter { availableSources.contains($0) }
+        
+        sourceTableView.delegate = self
+        sourceTableView.dataSource = self
+        sourceTableView.registerForDraggedTypes([.string])
+        
+        updateUI()
+    }
+    
+    @IBAction func toggleSourcePriority(_ sender: NSButton) {
+        let enabled = sender.state == .on
+        defaults[.lyricsSourcePriorityEnabled] = enabled
+        updateUI()
+    }
+    
+    private func updateUI() {
+        sourceTableView.isEnabled = defaults[.lyricsSourcePriorityEnabled]
+        sourceTableView.alphaValue = defaults[.lyricsSourcePriorityEnabled] ? 1.0 : 0.5
+    }
+    
+    private func savePriorityOrder() {
+        defaults[.lyricsSourcePriorityOrder] = sourcePriorityOrder
+    }
+}
+
+// MARK: - NSTableViewDataSource
+
+extension PreferenceSourceViewController: NSTableViewDataSource {
+    
+    func numberOfRows(in tableView: NSTableView) -> Int {
+        return sourcePriorityOrder.count
+    }
+    
+    func tableView(_ tableView: NSTableView, objectValueFor tableColumn: NSTableColumn?, row: Int) -> Any? {
+        guard row < sourcePriorityOrder.count else { return nil }
+        
+        let source = sourcePriorityOrder[row]
+        
+        if tableColumn?.identifier.rawValue == "priority" {
+            return "\(row + 1)"
+        } else if tableColumn?.identifier.rawValue == "source" {
+            return source
+        }
+        
+        return nil
+    }
+    
+    func tableView(_ tableView: NSTableView, writeRowsWith rowIndexes: IndexSet, to pboard: NSPasteboard) -> Bool {
+        guard let row = rowIndexes.first else { return false }
+        
+        pboard.declareTypes([.string], owner: self)
+        pboard.setString("\(row)", forType: .string)
+        return true
+    }
+    
+    func tableView(_ tableView: NSTableView, validateDrop info: NSDraggingInfo, proposedRow row: Int, proposedDropOperation dropOperation: NSTableView.DropOperation) -> NSDragOperation {
+        if dropOperation == .above {
+            return .move
+        }
+        return []
+    }
+    
+    func tableView(_ tableView: NSTableView, acceptDrop info: NSDraggingInfo, row: Int, dropOperation: NSTableView.DropOperation) -> Bool {
+        guard let data = info.draggingPasteboard.string(forType: .string),
+              let sourceRow = Int(data) else { return false }
+        
+        let targetRow = row > sourceRow ? row - 1 : row
+        let movedItem = sourcePriorityOrder.remove(at: sourceRow)
+        sourcePriorityOrder.insert(movedItem, at: targetRow)
+        
+        savePriorityOrder()
+        tableView.reloadData()
+        
+        return true
+    }
+}
+
+// MARK: - NSTableViewDelegate
+
+extension PreferenceSourceViewController: NSTableViewDelegate {
+    
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        guard row < sourcePriorityOrder.count,
+              let identifier = tableColumn?.identifier else { return nil }
+        
+        let cellView = tableView.makeView(withIdentifier: identifier, owner: self) as? NSTableCellView
+        
+        if identifier.rawValue == "priority" {
+            cellView?.textField?.stringValue = "\(row + 1)"
+        } else if identifier.rawValue == "source" {
+            cellView?.textField?.stringValue = sourcePriorityOrder[row]
+        }
+        
+        return cellView
+    }
+}

--- a/LyricsX/Search/SearchLyricsViewController.swift
+++ b/LyricsX/Search/SearchLyricsViewController.swift
@@ -120,7 +120,7 @@ class SearchLyricsViewController: NSViewController, NSTableViewDelegate, NSTable
         lyrics.filtrate()
         lyrics.recognizeLanguage()
         lyrics.metadata.needsPersist = true
-        if let idx = searchResult.firstIndex(where: { lyrics.quality > $0.quality }) {
+        if let idx = searchResult.firstIndex(where: { shouldInsertBefore(lyrics, $0) }) {
             searchResult.insert(lyrics, at: idx)
         } else {
             searchResult.append(lyrics)
@@ -128,6 +128,24 @@ class SearchLyricsViewController: NSViewController, NSTableViewDelegate, NSTable
         DispatchQueue.main.async {
             self.tableView.reloadData()
         }
+    }
+    
+   // Same as AppController.swift
+    private func shouldInsertBefore(_ newLyrics: Lyrics, _ existingLyrics: Lyrics) -> Bool {
+        if defaults[.lyricsSourcePriorityEnabled] {
+            let sourceOrder = defaults[.lyricsSourcePriorityOrder] ?? []
+            let newSource = newLyrics.metadata.service ?? ""
+            let existingSource = existingLyrics.metadata.service ?? ""
+            
+            let newSourceIndex = sourceOrder.firstIndex(of: newSource) ?? Int.max
+            let existingSourceIndex = sourceOrder.firstIndex(of: existingSource) ?? Int.max
+            
+            if newSourceIndex != existingSourceIndex {
+                return newSourceIndex < existingSourceIndex
+            }
+        }
+        
+        return newLyrics.quality > existingLyrics.quality
     }
 
     // MARK: - TableViewDelegate

--- a/LyricsX/Supporting Files/UserDefaults.plist
+++ b/LyricsX/Supporting Files/UserDefaults.plist
@@ -63,6 +63,16 @@
 	</array>
 	<key>GlobalLyricsOffset</key>
 	<integer>0</integer>
+	<key>LyricsSourcePriorityEnabled</key>
+	<false/>
+	<key>LyricsSourcePriorityOrder</key>
+	<array
+	    <string>Kugou</string>
+	    <string>LRCLIB</string>
+	    <string>NetEase</string>
+	    <string>QQMusic</string>
+	    <string>Spotify</string>>
+	</array>
 	<key>NSApplicationCrashOnExceptions</key>
 	<true/>
 </dict>

--- a/LyricsX/Supporting Files/UserDefaults.plist
+++ b/LyricsX/Supporting Files/UserDefaults.plist
@@ -66,12 +66,12 @@
 	<key>LyricsSourcePriorityEnabled</key>
 	<false/>
 	<key>LyricsSourcePriorityOrder</key>
-	<array
+	<array>
 	    <string>Kugou</string>
 	    <string>LRCLIB</string>
 	    <string>NetEase</string>
 	    <string>QQMusic</string>
-	    <string>Spotify</string>>
+	    <string>Spotify</string>
 	</array>
 	<key>NSApplicationCrashOnExceptions</key>
 	<true/>

--- a/LyricsX/Utility/Global.swift
+++ b/LyricsX/Utility/Global.swift
@@ -165,6 +165,11 @@ extension UserDefaults.DefaultsKeys {
     static let appleLanguages = Key<[String]>("AppleLanguages")
     
     static let isShowLyricsHUD = Key<Bool>("isShowLyricsHUD")
+    
+    // Source Priority
+    static let lyricsSourcePriorityEnabled = Key<Bool>("LyricsSourcePriorityEnabled")
+    static let lyricsSourcePriorityOrder = Key<[String]>("LyricsSourcePriorityOrder")
+    
 }
 
 extension CGFloat: @retroactive DefaultConstructible {}

--- a/LyricsX/mul.lproj/Preferences.xcstrings
+++ b/LyricsX/mul.lproj/Preferences.xcstrings
@@ -2623,6 +2623,120 @@
         }
       }
     },
+    "au8-ou-Duf.title" : {
+      "comment" : "Class = \"NSButtonCell\"; title = \"Enable source priority ranking\"; ObjectID = \"au8-ou-Duf\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تفعيل ترتيب المصادر حسب الأولوية"
+          }
+        },
+        "base" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable source priority ranking"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rangfolge nach Quellenpriorität aktivieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enable source priority ranking"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activar clasificación por prioridad de fuente"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "فعال‌سازی رتبه‌بندی اولویت منابع"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activer le classement par priorité des sources"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktifkan peringkat prioritas sumber"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abilita ordinamento per priorità delle fonti"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取得元の優先順位を有効にする"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "출처 우선 순위 순서 활성화"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rangschikking op bronprioriteit inschakelen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Włącz ranking priorytetów źródeł"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ativar classificação por prioridade da fonte"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Включить ранжирование источников по приоритету"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Увімкнути ранжування джерел за пріоритетом"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用歌词源优先级排序"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用歌詞源優先級排序"
+          }
+        }
+      }
+    },
     "aUg-eg-K5C.label" : {
       "comment" : "Class = \"NSTabViewItem\"; label = \"Karaoke\"; ObjectID = \"aUg-eg-K5C\";",
       "extractionState" : "extracted_with_value",
@@ -3873,6 +3987,114 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "一般"
+          }
+        }
+      }
+    },
+    "e8O-oC-igZ.title" : {
+      "comment" : "Class = \"NSTextFieldCell\"; title = \"Drag rows to reorder source priority. If disabled, it will be sorted by quality.\"; ObjectID = \"e8O-oC-igZ\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اسحب الصفوف لإعادة ترتيب أولوية المصدر. إذا تم تعطيله، سيتم الترتيب حسب الجودة."
+          }
+        },
+        "base" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Drag rows to reorder source priority. If disabled, it will be sorted by quality."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeilen ziehen, um die Quellenpriorität neu anzuordnen. Wenn deaktiviert, wird nach Qualität sortiert."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Drag rows to reorder source priority. If disabled, it will be sorted by quality."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arrastra las filas para reordenar la prioridad de la fuente. Si está desactivado, se ordenará por calidad."
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "برای ترتیب مجدد اولویت منابع، سطرها را بکشید. در صورت غیرفعال بودن، بر اساس کیفیت مرتب خواهد شد."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faites glisser les lignes pour réorganiser la priorité des sources. Si désactivé, le tri se fera par qualité."
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seret baris untuk menyusun ulang prioritas sumber. Jika dinonaktifkan, akan diurutkan berdasarkan kualitas."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trascina le righe per riordinare la priorità delle fonti. Se disabilitato, l'ordinamento avverrà per qualità."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行をドラッグして取得元の優先順位を変更します。無効の場合、品質順でソートされます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "행을 드래그하여 출처 우선 순위를 변경하세요. 비활성화 시 품질 순으로 정렬됩니다."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sleep rijen om de bronprioriteit opnieuw te rangschikken. Indien uitgeschakeld, wordt er op kwaliteit gesorteerd."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Przeciągnij wiersze, aby zmienić kolejność priorytetów źródeł. Jeśli opcja jest wyłączona, sortowanie odbędzie się według jakości."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arraste as linhas para reordenar a prioridade da fonte. Se desativado, será ordenado por qualidade.\n\n"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перетаскивайте строки, чтобы изменить приоритет источников. Если отключено, сортировка будет по качеству."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拖动以重新排序歌词源优先级。若关闭该功能则按照质量排序。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "可拖動調整歌詞來源的優先順序。停用時，則依照歌詞品質排列。"
           }
         }
       }
@@ -7863,6 +8085,120 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "不轉換"
+          }
+        }
+      }
+    },
+    "KTZ-mJ-lpY.title" : {
+      "comment" : "Class = \"NSViewController\"; title = \"Source\"; ObjectID = \"KTZ-mJ-lpY\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "المصدر"
+          }
+        },
+        "base" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Source"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quelle"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Source"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fuente"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "منبع"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Source"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sumber"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fonte"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取得元"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "출처"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bron"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Źródło"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fonte"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Источник"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Джерело"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歌词源"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歌詞來源"
           }
         }
       }
@@ -11875,6 +12211,120 @@
         }
       }
     },
+    "Vdv-QC-53v.headerCell.title" : {
+      "comment" : "Class = \"NSTableColumn\"; headerCell.title = \"Priority\"; ObjectID = \"Vdv-QC-53v\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الأولوية"
+          }
+        },
+        "base" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Priority"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Priorität"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Priority"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prioridad"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اولویت"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Priorité"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prioritas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Priorità"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "優先"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "우선 순위"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prioriteit"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Priorytet"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prioridade"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Приоритет"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пріоритет"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "优先级"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "優先級"
+          }
+        }
+      }
+    },
     "vUt-b5-jlE.title" : {
       "comment" : "Class = \"NSButtonCell\"; title = \"Load lyrics beside music file\"; ObjectID = \"vUt-b5-jlE\";",
       "extractionState" : "extracted_with_value",
@@ -13466,6 +13916,120 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "登入"
+          }
+        }
+      }
+    },
+    "xXN-7W-SKY.headerCell.title" : {
+      "comment" : "Class = \"NSTableColumn\"; headerCell.title = \"Source\"; ObjectID = \"xXN-7W-SKY\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "المصدر"
+          }
+        },
+        "base" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Source"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quelle"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Source"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fuente"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "منبع"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Source"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sumber"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fonte"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取得元"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "출처"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bron"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Źródło"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fonte"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Источник"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Джерело"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歌词源"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歌詞來源"
           }
         }
       }

--- a/LyricsX/mul.lproj/Preferences.xcstrings
+++ b/LyricsX/mul.lproj/Preferences.xcstrings
@@ -4076,7 +4076,7 @@
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Arraste as linhas para reordenar a prioridade da fonte. Se desativado, será ordenado por qualidade.\n\n"
+            "value" : "Arraste as linhas para reordenar a prioridade da fonte. Se desativado, será ordenado por qualidade."
           }
         },
         "ru" : {


### PR DESCRIPTION
As mentioned in some issues (such as #102, #67), I have added the function of prioritizing lyrics sources.

For me personally, I prefer to applying lyrics with karaoke effects, so I have always hoped to make lyrics obtained from LRCLIB and QQMusic my first choice.

Preview:

<img width="1020" height="601" alt="disabled" src="https://github.com/user-attachments/assets/8e933749-9b5a-4acf-856e-44598257a669" />

<img width="1020" height="601" alt="enabled" src="https://github.com/user-attachments/assets/fef6a5ea-3aad-4785-beb5-caaa2d01842e" />

**NOTE:** Because I observe that LyricsKit does not frequently add or remove sources, I am temporarily using a fixed list and will try to add some features to LyricsKit later.