### PR TITLE
fix: make source-priority comparison case‑insensitive

### DIFF
--- a/LyricsX/Component/AppController.swift
+++ b/LyricsX/Component/AppController.swift
@@ -266,11 +266,14 @@ class AppController: NSObject {
         // If source priority is enabled, use it for comparison
         if defaults[.lyricsSourcePriorityEnabled] {
             let sourceOrder = defaults[.lyricsSourcePriorityOrder] ?? []
-            let currentSource = current.metadata.service ?? ""
-            let newSource = new.metadata.service ?? ""
+            // Normalize to lowercase to perform case-insensitive comparison
+            let normalizedOrder = sourceOrder.map { $0.lowercased() }
 
-            let currentSourceIndex = sourceOrder.firstIndex(of: currentSource) ?? Int.max
-            let newSourceIndex = sourceOrder.firstIndex(of: newSource) ?? Int.max
+            let currentSource = (current.metadata.service ?? "").lowercased()
+            let newSource = (new.metadata.service ?? "").lowercased()
+
+            let currentSourceIndex = normalizedOrder.firstIndex(of: currentSource) ?? Int.max
+            let newSourceIndex = normalizedOrder.firstIndex(of: newSource) ?? Int.max
 
             if currentSourceIndex != newSourceIndex {
                 return newSourceIndex < currentSourceIndex

--- a/LyricsX/Search/SearchLyricsViewController.swift
+++ b/LyricsX/Search/SearchLyricsViewController.swift
@@ -131,11 +131,13 @@ class SearchLyricsViewController: NSViewController, NSTableViewDelegate, NSTable
     private func shouldInsertBefore(_ newLyrics: Lyrics, _ existingLyrics: Lyrics) -> Bool {
         if defaults[.lyricsSourcePriorityEnabled] {
             let sourceOrder = defaults[.lyricsSourcePriorityOrder] ?? []
-            let newSource = newLyrics.metadata.service ?? ""
-            let existingSource = existingLyrics.metadata.service ?? ""
+            let normalizedOrder = sourceOrder.map { $0.lowercased() }
 
-            let newSourceIndex = sourceOrder.firstIndex(of: newSource) ?? Int.max
-            let existingSourceIndex = sourceOrder.firstIndex(of: existingSource) ?? Int.max
+            let newSource = (newLyrics.metadata.service ?? "").lowercased()
+            let existingSource = (existingLyrics.metadata.service ?? "").lowercased()
+
+            let newSourceIndex = normalizedOrder.firstIndex(of: newSource) ?? Int.max
+            let existingSourceIndex = normalizedOrder.firstIndex(of: existingSource) ?? Int.max
 
             if newSourceIndex != existingSourceIndex {
                 return newSourceIndex < existingSourceIndex


### PR DESCRIPTION
Related with this [issue](https://github.com/MxIris-LyricsX-Project/LyricsX/pull/103#issuecomment-3477145069) by [@Undefined-User](https://github.com/Undefined-User).

<img width="610" height="219" alt="Snipaste_2025-11-02_11-09-22" src="https://github.com/user-attachments/assets/a9ed6246-fdb0-4ac7-8599-5646051e26b2" />

Now the lyrics from NetEase can be sorted correctly.

<img width="600" height="255" alt="Snipaste_2025-11-02_11-08-00" src="https://github.com/user-attachments/assets/3675906b-074b-43cc-a973-483cbbee4088" />

<img width="600" height="255" alt="Snipaste_2025-11-02_11-08-45" src="https://github.com/user-attachments/assets/89ae0506-0c81-4d26-bd47-525cd1e0b175" />