### PR TITLE
fix: 修复歌词卡死最后一行 + 状态校正时进度条闪烁

### DIFF
--- a/LyricsX/Component/AppController.swift
+++ b/LyricsX/Component/AppController.swift
@@ -48,9 +48,18 @@ class AppController: NSObject {
             .invoke(AppController.currentTrackChanged, weaklyOn: self)
             .store(in: &cancelBag)
         selectedPlayer.playbackStateWillChange
+            .receive(on: DispatchQueue.lyricsDisplay)
+            .invoke(AppController.playbackStateChanged, weaklyOn: self)
+            .store(in: &cancelBag)
+        // `lyrics.adjustedTimeDelay` reads `globalLyricsOffset` dynamically, so a
+        // change must reschedule `currentLineIndex`. Per-track offset is handled
+        // by the `lyricsOffset` setter; the global key has no setter path here.
+        defaults.publisher(for: [.globalLyricsOffset])
             .signal()
             .receive(on: DispatchQueue.lyricsDisplay)
-            .invoke(AppController.scheduleCurrentLineCheck, weaklyOn: self)
+            .sink { [weak self] in
+                self?.scheduleCurrentLineCheck()
+            }
             .store(in: &cancelBag)
 
         workspaceNC.publisher(for: NSWorkspace.didTerminateApplicationNotification, object: nil)
@@ -88,24 +97,76 @@ class AppController: NSObject {
 
     var currentLineCheckSchedule: Cancellable?
 
-    func scheduleCurrentLineCheck() {
+    // Reschedule on every publish. The schedule path is cheap (timer
+    // cancel + binary search + new timer, ~10µs per call) and any form
+    // of dedup here would let the previously scheduled timer keep
+    // firing on a stale wallclock anchor, lagging or leading the real
+    // playback boundary. Passing the anchor-derived `PlaybackState`
+    // from the publish through to the schedule, instead of re-reading
+    // the cached `selectedPlayer` value, is preserved by routing every
+    // event through here.
+    private func playbackStateChanged(_ playbackState: PlaybackState) {
+        scheduleCurrentLineCheck(playbackState: playbackState)
+    }
+
+    func scheduleCurrentLineCheck(playbackState: PlaybackState? = nil) {
         currentLineCheckSchedule?.cancel()
         guard let lyrics = currentLyrics else {
             return
         }
-        let playbackState = MusicPlayers.Selected.shared.playbackState
-        let playbackTime = playbackState.time
+        // Use the anchor-derived `PlaybackState.time` rather than the
+        // delegate-cached `selectedPlayer.playbackTime`. The latter can lag
+        // around repeat-one wrap and track-change boundaries, leaving the
+        // lyric index stalled while playback has actually moved on.
+        let resolvedPlaybackState = playbackState ?? MusicPlayers.Selected.shared.playbackState
+        let trackDuration = selectedPlayer.currentTrack?.duration
+        let playbackTime = resolvedPlaybackState.lyricsDisplayTime(trackDuration: trackDuration)
         let (index, next) = lyrics[playbackTime + lyrics.adjustedTimeDelay]
         if currentLineIndex != index {
             currentLineIndex = index
         }
-        if let next = next, playbackState.isPlaying {
-            let dt = lyrics.lines[next].position - playbackTime - lyrics.adjustedTimeDelay
-            let q = DispatchQueue.lyricsDisplay
-            currentLineCheckSchedule = q.schedule(after: q.now.advanced(by: .seconds(dt)), interval: .seconds(42), tolerance: .milliseconds(20)) { [unowned self] in
+        let q = DispatchQueue.lyricsDisplay
+        if let next = next, resolvedPlaybackState.isPlaying {
+            let dt = max(0, lyrics.lines[next].position - playbackTime - lyrics.adjustedTimeDelay)
+            currentLineCheckSchedule = q.schedule(
+                after: q.now.advanced(by: .seconds(dt)),
+                interval: .seconds(42),
+                tolerance: .milliseconds(20)
+            ) { [unowned self] in
+                self.scheduleCurrentLineCheck()
+            }
+        } else if resolvedPlaybackState.isPlaying {
+            // Past the last lyric line but still playing: keep a recovery edge
+            // for missed state publishes, and snap the next check to the track
+            // duration plus a short confirmation window when it is closer than
+            // the regular polling interval.
+            // Combined with `lyricsDisplayTime(trackDuration:)`, this lets
+            // repeat-one wrap back to the opening lyric without waiting for the
+            // next one-second poll when the player keeps the old playback anchor.
+            let nextCheckDelay = Self.lastLineCheckDelay(playbackTime: playbackTime, trackDuration: trackDuration)
+            let tolerance: DispatchQueue.SchedulerTimeType.Stride = nextCheckDelay < 1 ? .milliseconds(20) : .milliseconds(100)
+            currentLineCheckSchedule = q.schedule(
+                after: q.now.advanced(by: .seconds(nextCheckDelay)),
+                interval: .seconds(1),
+                tolerance: tolerance
+            ) { [unowned self] in
                 self.scheduleCurrentLineCheck()
             }
         }
+    }
+
+    private static func lastLineCheckDelay(playbackTime: TimeInterval, trackDuration: TimeInterval?) -> TimeInterval {
+        guard playbackTime.isFinite,
+              let trackDuration = trackDuration,
+              trackDuration.isFinite,
+              trackDuration > 0 else {
+            return 1
+        }
+        let wrapCheckTime = trackDuration + PlaybackState.lyricsRepeatWrapGracePeriod
+        guard wrapCheckTime > playbackTime else {
+            return 1
+        }
+        return min(1, wrapCheckTime - playbackTime)
     }
 
     func writeToiTunes(overwrite: Bool) {

--- a/LyricsX/Controller/KaraokeLyricsController.swift
+++ b/LyricsX/Controller/KaraokeLyricsController.swift
@@ -45,14 +45,19 @@ class KaraokeLyricsWindowController: NSWindowController {
                 .receive(on: DispatchQueue.lyricsDisplay)
                 .invoke(KaraokeLyricsWindowController.handleLyricsDisplay, weaklyOn: self)
                 .store(in: &self.cancelBag)
-            selectedPlayer.playbackStateWillChange
+            AppController.shared.publisher(for: \.lyricsOffset)
                 .signal()
                 .receive(on: DispatchQueue.lyricsDisplay)
-                .invoke(KaraokeLyricsWindowController.handleLyricsDisplay, weaklyOn: self)
+                .invoke(KaraokeLyricsWindowController.lyricsOffsetChanged, weaklyOn: self)
                 .store(in: &self.cancelBag)
-            defaults.publisher(for: [.preferBilingualLyrics, .desktopLyricsOneLineMode])
+            selectedPlayer.playbackStateWillChange
+                .receive(on: DispatchQueue.lyricsDisplay)
+                .invoke(KaraokeLyricsWindowController.playbackStateChanged, weaklyOn: self)
+                .store(in: &self.cancelBag)
+            defaults.publisher(for: Self.displayRefreshPreferenceKeys)
                 .prepend()
-                .invoke(KaraokeLyricsWindowController.handleLyricsDisplay, weaklyOn: self)
+                .receive(on: DispatchQueue.lyricsDisplay)
+                .invoke(KaraokeLyricsWindowController.displayPreferencesChanged, weaklyOn: self)
                 .store(in: &self.cancelBag)
         }
     }
@@ -107,16 +112,162 @@ class KaraokeLyricsWindowController: NSWindowController {
         window?.saveFrame(usingName: KaraokeLyricsWindowController.windowFrame)
     }
 
+    // Mirrors the Cocoa bindings / observeDefaults set above. Those
+    // main-thread invalidations can tear down `inlineProgress`, so these
+    // preference publishes re-install it after the bindings settle.
+    private static let displayRefreshPreferenceKeys: [UserDefaults.DefaultsKeys] = [
+        .desktopLyricsEnabled,
+        .disableLyricsWhenPaused,
+        .preferBilingualLyrics,
+        .desktopLyricsOneLineMode,
+        .chineseConversionIndex,
+        .globalLyricsOffset,
+        .desktopLyricsVerticalMode,
+        .desktopLyricsEnableFurigana,
+        .desktopLyricsEnableRomajin,
+        .desktopLyricsFontName,
+        .desktopLyricsFontSize,
+        .desktopLyricsFontNameFallback,
+        .desktopLyricsColor,
+        .desktopLyricsProgressColor,
+        .desktopLyricsShadowColor,
+        .desktopLyricsBackgroundColor,
+    ]
+
+    // Captures playback/content state for the current render. Repeated
+    // `playbackStateWillChange` publishes for the same line otherwise tear
+    // down and re-add the karaoke `inlineProgress` animation each call,
+    // which restarts it from `values[0]` (the current playback offset).
+    // When the publisher fires faster than the animation can advance, the
+    // progress stays pinned near zero — visible as the "stuck at 0s"
+    // first-line flicker reported in single-song repeat.
+    private struct DisplayKey: Equatable {
+        let lyricsId: ObjectIdentifier
+        let lineIndex: Int
+        let isPlaying: Bool
+        let preferBilingual: Bool
+        let oneLineMode: Bool
+        let chineseConversionIndex: Int
+        // Quantized to ms so floating-point equality is stable. The
+        // progress animation below interpolates each timetag against
+        // `adjustedTimeDelay`, so a change here (user adjusts global
+        // or per-track lyric offset) must invalidate the cached
+        // render even when staying on the same line.
+        let timeDelayMs: Int
+    }
+
+    private var lastShowingKey: DisplayKey?
+    private var lastRenderedPlaybackState: PlaybackState?
+    private var lastRenderedWallclock: Date?
+    private var hasDisplayedLyrics = false
+    private var pendingDisplayPreferenceRefresh = false
+
+    private func playbackStateChanged(_ playbackState: PlaybackState) {
+        handleLyricsDisplay(playbackState: playbackState)
+    }
+
+    private func lyricsOffsetChanged() {
+        invalidateDisplayedLine()
+        handleLyricsDisplay()
+    }
+
+    private func displayPreferencesChanged() {
+        invalidateDisplayedLine()
+
+        guard !pendingDisplayPreferenceRefresh else { return }
+        pendingDisplayPreferenceRefresh = true
+
+        // KVO for UserDefaults and Cocoa bindings can be delivered in the same
+        // turn. Refresh after the main-thread bindings have invalidated
+        // KaraokeLabel caches so the newly installed progress animation is not
+        // immediately removed by font/color/layout updates.
+        DispatchQueue.main.async {
+            DispatchQueue.lyricsDisplay.async { [weak self] in
+                guard let self = self else { return }
+                self.pendingDisplayPreferenceRefresh = false
+                self.invalidateDisplayedLine()
+                self.handleLyricsDisplay()
+            }
+        }
+    }
+
+    private func invalidateDisplayedLine() {
+        lastShowingKey = nil
+        lastRenderedPlaybackState = nil
+        lastRenderedWallclock = nil
+    }
+
+    private func clearDisplayedLyricsIfNeeded() {
+        lastShowingKey = nil
+        guard hasDisplayedLyrics else { return }
+        hasDisplayedLyrics = false
+        DispatchQueue.main.async {
+            self.lyricsView.displayLrc("", secondLine: "")
+        }
+    }
+
     @objc private func handleLyricsDisplay() {
+        handleLyricsDisplay(playbackState: selectedPlayer.playbackState)
+    }
+
+    private func handleLyricsDisplay(playbackState: PlaybackState) {
+        let isPlaying = playbackState.isPlaying
         guard defaults[.desktopLyricsEnabled],
-              !defaults[.disableLyricsWhenPaused] || selectedPlayer.playbackState.isPlaying,
+              !defaults[.disableLyricsWhenPaused] || isPlaying,
               let lyrics = AppController.shared.currentLyrics,
               let index = AppController.shared.currentLineIndex else {
-            DispatchQueue.main.async {
-                self.lyricsView.displayLrc("", secondLine: "")
-            }
+            lastRenderedPlaybackState = nil
+            lastRenderedWallclock = nil
+            clearDisplayedLyricsIfNeeded()
             return
         }
+
+        // Re-anchor the progress animation only when playback actually
+        // jumps. We extrapolate the previous state forward by wallclock
+        // (linear when playing, frozen when paused) and treat any drift
+        // beyond ~80ms as a real seek/buffer/wrap-around — which is when
+        // the animation needs to be re-installed against a fresh anchor.
+        // Linear playback inside a single line stays anchored, so the
+        // running keyframe animation continues uninterrupted, and the
+        // highlight tracks playback to within the jump threshold (vs.
+        // up to 0.5s of drift previously).
+        let didJump: Bool
+        if let lastState = lastRenderedPlaybackState, let lastWall = lastRenderedWallclock {
+            let elapsed = Date().timeIntervalSince(lastWall)
+            let predicted: TimeInterval
+            switch lastState {
+            case .playing:
+                predicted = lastState.time
+            case .fastForwarding(let time):
+                predicted = time + elapsed
+            case .rewinding(let time):
+                predicted = time - elapsed
+            case .paused(let time):
+                predicted = time
+            case .stopped:
+                predicted = 0
+            }
+            didJump = abs(playbackState.time - predicted) > 0.08
+        } else {
+            didJump = true
+        }
+        let trackDuration = selectedPlayer.currentTrack?.duration
+        let key = DisplayKey(
+            lyricsId: ObjectIdentifier(lyrics),
+            lineIndex: index,
+            isPlaying: isPlaying,
+            preferBilingual: defaults[.preferBilingualLyrics],
+            oneLineMode: defaults[.desktopLyricsOneLineMode],
+            chineseConversionIndex: defaults[.chineseConversionIndex],
+            timeDelayMs: Int((lyrics.adjustedTimeDelay * 1000).rounded())
+        )
+        if lastShowingKey == key && !didJump {
+            return
+        }
+        lastShowingKey = key
+        lastRenderedPlaybackState = playbackState
+        lastRenderedWallclock = Date()
+        hasDisplayedLyrics = true
 
         let lrc = lyrics.lines[index]
         let next = lyrics.lines[(index + 1)...].first { $0.enabled }
@@ -148,15 +299,23 @@ class KaraokeLyricsWindowController: NSWindowController {
             }
         }
 
+        // Capture the offset on `lyricsDisplay` so the progress animation
+        // below is computed against the same lyrics that produced `lrc`
+        // and `index`. Re-reading `AppController.shared.currentLyrics`
+        // inside the `main.async` block would race with track switching
+        // and could mix the old line with the new song's offset.
+        let timeDelay = lyrics.adjustedTimeDelay
         DispatchQueue.main.async {
             self.lyricsView.displayLrc(firstLine, secondLine: secondLine)
             if let upperTextField = self.lyricsView.displayLine1,
                let timetag = lrc.attachments.timetag {
-                let position = selectedPlayer.playbackTime
-                let timeDelay = AppController.shared.currentLyrics?.adjustedTimeDelay ?? 0
+                // Anchor on the PlaybackState that triggered this render so the
+                // animation is not seeded from a stale `selectedPlayer.playbackTime`
+                // around repeat-one wrap or track-change boundaries.
+                let position = playbackState.lyricsDisplayTime(trackDuration: trackDuration)
                 let progress = timetag.tags.map { ($0.time + lrc.position - timeDelay - position, $0.index) }
                 upperTextField.setProgressAnimation(color: self.lyricsView.progressColor, progress: progress)
-                if !selectedPlayer.playbackState.isPlaying {
+                if !isPlaying {
                     upperTextField.pauseProgressAnimation()
                 }
             }

--- a/LyricsX/TouchBar/TouchBarLyricsItem.swift
+++ b/LyricsX/TouchBar/TouchBarLyricsItem.swift
@@ -45,13 +45,18 @@ class TouchBarLyricsItem: NSCustomTouchBarItem {
            lyrics.metadata.language?.hasPrefix("zh") == true {
             lyricsContent = converter.convert(lyricsContent)
         }
+        let playbackState = selectedPlayer.playbackState
+        let trackDuration = selectedPlayer.currentTrack?.duration
+        let timeDelay = lyrics.adjustedTimeDelay
+        let position = playbackState.lyricsDisplayTime(trackDuration: trackDuration)
         DispatchQueue.main.async {
             self.lyricsTextField.stringValue = lyricsContent
             if let timetag = line.attachments.timetag {
-                let position = selectedPlayer.playbackTime
-                let timeDelay = line.lyrics?.adjustedTimeDelay ?? 0
                 let progress = timetag.tags.map { ($0.time + line.position - timeDelay - position, $0.index) }
                 self.lyricsTextField.setProgressAnimation(color: self.progressColor, progress: progress)
+                if !playbackState.isPlaying {
+                    self.lyricsTextField.pauseProgressAnimation()
+                }
             }
         }
     }

--- a/LyricsX/Utility/Extension.swift
+++ b/LyricsX/Utility/Extension.swift
@@ -26,6 +26,23 @@ extension MusicPlayerName {
     }
 }
 
+extension PlaybackState {
+    static var lyricsRepeatWrapGracePeriod: TimeInterval { 0.5 }
+
+    func lyricsDisplayTime(trackDuration: TimeInterval?) -> TimeInterval {
+        let playbackTime = time
+        guard isPlaying,
+              playbackTime.isFinite,
+              let trackDuration = trackDuration,
+              trackDuration.isFinite,
+              trackDuration > 0,
+              playbackTime >= trackDuration + Self.lyricsRepeatWrapGracePeriod else {
+            return playbackTime
+        }
+        return playbackTime.truncatingRemainder(dividingBy: trackDuration)
+    }
+}
+
 extension MusicTrack {
     var lyrics: String? {
         guard let originalTrack = originalTrack,


### PR DESCRIPTION
## 问题

1. 歌词（可能）卡在最后一行不动：循环后歌词不再前进，或播放新歌时直接定格在新歌最后一行而不是从头开始。
2. 状态校正时进度条闪烁：播放器纠正时间时（缓冲、小漂移），`handleLyricsDisplay` 重跑一遍，正在跑的进度条动画被打断重置。

## 根因

`scheduleCurrentLineCheck` 只在还有 `next` 行时才安排下一次检查。一旦过了最后一句（`next == nil`），状态机就没有自我恢复的边了，只能靠 `playbackStateWillChange` 唤醒，但单曲循环时此事件不可靠。

## 改动

- `AppController.swift`：`next == nil && isPlaying` 加 1Hz 轮询。
- `KaraokeLyricsController.swift`：缓存上一次实际渲染的 key，下次进来如果 (lyricsId, lineIndex, isPlaying, ...) 都没变就 SKIP，不打断在跑的关键帧动画。

## 另

第二个修改是为了解决 MusicPlayer 那边，修复开始播放时会持续有延迟 的副作用。见：https://github.com/MxIris-LyricsX-Project/MusicPlayer/pull/2