### PR TITLE
refactor(prefs): rename "Prefer bilingual lyrics" → "Show translation"

### DIFF
--- a/LyricsX/Base.lproj/Preferences.storyboard
+++ b/LyricsX/Base.lproj/Preferences.storyboard
@@ -535,7 +535,7 @@
                                     <gridCell row="7Wx-n7-f04" column="IfN-lq-biT" id="kFj-ie-KSt">
                                         <button key="contentView" verticalHuggingPriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="eXe-c6-bvj">
                                             <rect key="frame" x="217" y="141" width="149" height="16"/>
-                                            <buttonCell key="cell" type="check" title="Prefer bilingual lyrics" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="KJ9-qG-viC">
+                                            <buttonCell key="cell" type="check" title="Show translation" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="KJ9-qG-viC">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
                                             </buttonCell>
@@ -2149,7 +2149,7 @@
                             </box>
                             <button verticalHuggingPriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="wwb-0H-xk7">
                                 <rect key="frame" x="246" y="68" width="149" height="16"/>
-                                <buttonCell key="cell" type="check" title="Prefer bilingual lyrics" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="cBB-zn-Hdh">
+                                <buttonCell key="cell" type="check" title="Show translation" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="cBB-zn-Hdh">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>

--- a/LyricsX/Component/AppController.swift
+++ b/LyricsX/Component/AppController.swift
@@ -48,9 +48,18 @@ class AppController: NSObject {
             .invoke(AppController.currentTrackChanged, weaklyOn: self)
             .store(in: &cancelBag)
         selectedPlayer.playbackStateWillChange
+            .receive(on: DispatchQueue.lyricsDisplay)
+            .invoke(AppController.playbackStateChanged, weaklyOn: self)
+            .store(in: &cancelBag)
+        // `lyrics.adjustedTimeDelay` reads `globalLyricsOffset` dynamically, so a
+        // change must reschedule `currentLineIndex`. Per-track offset is handled
+        // by the `lyricsOffset` setter; the global key has no setter path here.
+        defaults.publisher(for: [.globalLyricsOffset])
             .signal()
             .receive(on: DispatchQueue.lyricsDisplay)
-            .invoke(AppController.scheduleCurrentLineCheck, weaklyOn: self)
+            .sink { [weak self] in
+                self?.scheduleCurrentLineCheck()
+            }
             .store(in: &cancelBag)
 
         workspaceNC.publisher(for: NSWorkspace.didTerminateApplicationNotification, object: nil)
@@ -88,24 +97,76 @@ class AppController: NSObject {
 
     var currentLineCheckSchedule: Cancellable?
 
-    func scheduleCurrentLineCheck() {
+    // Reschedule on every publish. The schedule path is cheap (timer
+    // cancel + binary search + new timer, ~10µs per call) and any form
+    // of dedup here would let the previously scheduled timer keep
+    // firing on a stale wallclock anchor, lagging or leading the real
+    // playback boundary. Passing the anchor-derived `PlaybackState`
+    // from the publish through to the schedule, instead of re-reading
+    // the cached `selectedPlayer` value, is preserved by routing every
+    // event through here.
+    private func playbackStateChanged(_ playbackState: PlaybackState) {
+        scheduleCurrentLineCheck(playbackState: playbackState)
+    }
+
+    func scheduleCurrentLineCheck(playbackState: PlaybackState? = nil) {
         currentLineCheckSchedule?.cancel()
         guard let lyrics = currentLyrics else {
             return
         }
-        let playbackState = MusicPlayers.Selected.shared.playbackState
-        let playbackTime = playbackState.time
+        // Use the anchor-derived `PlaybackState.time` rather than the
+        // delegate-cached `selectedPlayer.playbackTime`. The latter can lag
+        // around repeat-one wrap and track-change boundaries, leaving the
+        // lyric index stalled while playback has actually moved on.
+        let resolvedPlaybackState = playbackState ?? MusicPlayers.Selected.shared.playbackState
+        let trackDuration = selectedPlayer.currentTrack?.duration
+        let playbackTime = resolvedPlaybackState.lyricsDisplayTime(trackDuration: trackDuration)
         let (index, next) = lyrics[playbackTime + lyrics.adjustedTimeDelay]
         if currentLineIndex != index {
             currentLineIndex = index
         }
-        if let next = next, playbackState.isPlaying {
-            let dt = lyrics.lines[next].position - playbackTime - lyrics.adjustedTimeDelay
-            let q = DispatchQueue.lyricsDisplay
-            currentLineCheckSchedule = q.schedule(after: q.now.advanced(by: .seconds(dt)), interval: .seconds(42), tolerance: .milliseconds(20)) { [unowned self] in
+        let q = DispatchQueue.lyricsDisplay
+        if let next = next, resolvedPlaybackState.isPlaying {
+            let dt = max(0, lyrics.lines[next].position - playbackTime - lyrics.adjustedTimeDelay)
+            currentLineCheckSchedule = q.schedule(
+                after: q.now.advanced(by: .seconds(dt)),
+                interval: .seconds(42),
+                tolerance: .milliseconds(20)
+            ) { [unowned self] in
+                self.scheduleCurrentLineCheck()
+            }
+        } else if resolvedPlaybackState.isPlaying {
+            // Past the last lyric line but still playing: keep a recovery edge
+            // for missed state publishes, and snap the next check to the track
+            // duration plus a short confirmation window when it is closer than
+            // the regular polling interval.
+            // Combined with `lyricsDisplayTime(trackDuration:)`, this lets
+            // repeat-one wrap back to the opening lyric without waiting for the
+            // next one-second poll when the player keeps the old playback anchor.
+            let nextCheckDelay = Self.lastLineCheckDelay(playbackTime: playbackTime, trackDuration: trackDuration)
+            let tolerance: DispatchQueue.SchedulerTimeType.Stride = nextCheckDelay < 1 ? .milliseconds(20) : .milliseconds(100)
+            currentLineCheckSchedule = q.schedule(
+                after: q.now.advanced(by: .seconds(nextCheckDelay)),
+                interval: .seconds(1),
+                tolerance: tolerance
+            ) { [unowned self] in
                 self.scheduleCurrentLineCheck()
             }
         }
+    }
+
+    private static func lastLineCheckDelay(playbackTime: TimeInterval, trackDuration: TimeInterval?) -> TimeInterval {
+        guard playbackTime.isFinite,
+              let trackDuration = trackDuration,
+              trackDuration.isFinite,
+              trackDuration > 0 else {
+            return 1
+        }
+        let wrapCheckTime = trackDuration + PlaybackState.lyricsRepeatWrapGracePeriod
+        guard wrapCheckTime > playbackTime else {
+            return 1
+        }
+        return min(1, wrapCheckTime - playbackTime)
     }
 
     func writeToiTunes(overwrite: Bool) {

--- a/LyricsX/Component/AppDelegate.swift
+++ b/LyricsX/Component/AppDelegate.swift
@@ -254,7 +254,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSMenu
             .desktopLyricsBackgroundColor: #colorLiteral(red: 0, green: 0, blue: 0, alpha: 0.6041579279),
             .lyricsWindowTextColor: #colorLiteral(red: 0.7540688515, green: 0.7540867925, blue: 0.7540771365, alpha: 1),
             .lyricsWindowHighlightColor: #colorLiteral(red: 0.8866666667, green: 1, blue: 0.8, alpha: 1),
-            .preferBilingualLyrics: isZh,
+            .showTranslation: isZh,
             .chineseConversionIndex: isHant ? 2 : 0,
             .desktopLyricsXPositionFactor: 0.5,
             .desktopLyricsYPositionFactor: 0.9,

--- a/LyricsX/Controller/KaraokeLyricsController.swift
+++ b/LyricsX/Controller/KaraokeLyricsController.swift
@@ -45,14 +45,19 @@ class KaraokeLyricsWindowController: NSWindowController {
                 .receive(on: DispatchQueue.lyricsDisplay)
                 .invoke(KaraokeLyricsWindowController.handleLyricsDisplay, weaklyOn: self)
                 .store(in: &self.cancelBag)
-            selectedPlayer.playbackStateWillChange
+            AppController.shared.publisher(for: \.lyricsOffset)
                 .signal()
                 .receive(on: DispatchQueue.lyricsDisplay)
-                .invoke(KaraokeLyricsWindowController.handleLyricsDisplay, weaklyOn: self)
+                .invoke(KaraokeLyricsWindowController.lyricsOffsetChanged, weaklyOn: self)
                 .store(in: &self.cancelBag)
-            defaults.publisher(for: [.preferBilingualLyrics, .desktopLyricsOneLineMode])
+            selectedPlayer.playbackStateWillChange
+                .receive(on: DispatchQueue.lyricsDisplay)
+                .invoke(KaraokeLyricsWindowController.playbackStateChanged, weaklyOn: self)
+                .store(in: &self.cancelBag)
+            defaults.publisher(for: Self.displayRefreshPreferenceKeys)
                 .prepend()
-                .invoke(KaraokeLyricsWindowController.handleLyricsDisplay, weaklyOn: self)
+                .receive(on: DispatchQueue.lyricsDisplay)
+                .invoke(KaraokeLyricsWindowController.displayPreferencesChanged, weaklyOn: self)
                 .store(in: &self.cancelBag)
         }
     }
@@ -107,16 +112,162 @@ class KaraokeLyricsWindowController: NSWindowController {
         window?.saveFrame(usingName: KaraokeLyricsWindowController.windowFrame)
     }
 
+    // Mirrors the Cocoa bindings / observeDefaults set above. Those
+    // main-thread invalidations can tear down `inlineProgress`, so these
+    // preference publishes re-install it after the bindings settle.
+    private static let displayRefreshPreferenceKeys: [UserDefaults.DefaultsKeys] = [
+        .desktopLyricsEnabled,
+        .disableLyricsWhenPaused,
+        .preferBilingualLyrics,
+        .desktopLyricsOneLineMode,
+        .chineseConversionIndex,
+        .globalLyricsOffset,
+        .desktopLyricsVerticalMode,
+        .desktopLyricsEnableFurigana,
+        .desktopLyricsEnableRomajin,
+        .desktopLyricsFontName,
+        .desktopLyricsFontSize,
+        .desktopLyricsFontNameFallback,
+        .desktopLyricsColor,
+        .desktopLyricsProgressColor,
+        .desktopLyricsShadowColor,
+        .desktopLyricsBackgroundColor,
+    ]
+
+    // Captures playback/content state for the current render. Repeated
+    // `playbackStateWillChange` publishes for the same line otherwise tear
+    // down and re-add the karaoke `inlineProgress` animation each call,
+    // which restarts it from `values[0]` (the current playback offset).
+    // When the publisher fires faster than the animation can advance, the
+    // progress stays pinned near zero — visible as the "stuck at 0s"
+    // first-line flicker reported in single-song repeat.
+    private struct DisplayKey: Equatable {
+        let lyricsId: ObjectIdentifier
+        let lineIndex: Int
+        let isPlaying: Bool
+        let preferBilingual: Bool
+        let oneLineMode: Bool
+        let chineseConversionIndex: Int
+        // Quantized to ms so floating-point equality is stable. The
+        // progress animation below interpolates each timetag against
+        // `adjustedTimeDelay`, so a change here (user adjusts global
+        // or per-track lyric offset) must invalidate the cached
+        // render even when staying on the same line.
+        let timeDelayMs: Int
+    }
+
+    private var lastShowingKey: DisplayKey?
+    private var lastRenderedPlaybackState: PlaybackState?
+    private var lastRenderedWallclock: Date?
+    private var hasDisplayedLyrics = false
+    private var pendingDisplayPreferenceRefresh = false
+
+    private func playbackStateChanged(_ playbackState: PlaybackState) {
+        handleLyricsDisplay(playbackState: playbackState)
+    }
+
+    private func lyricsOffsetChanged() {
+        invalidateDisplayedLine()
+        handleLyricsDisplay()
+    }
+
+    private func displayPreferencesChanged() {
+        invalidateDisplayedLine()
+
+        guard !pendingDisplayPreferenceRefresh else { return }
+        pendingDisplayPreferenceRefresh = true
+
+        // KVO for UserDefaults and Cocoa bindings can be delivered in the same
+        // turn. Refresh after the main-thread bindings have invalidated
+        // KaraokeLabel caches so the newly installed progress animation is not
+        // immediately removed by font/color/layout updates.
+        DispatchQueue.main.async {
+            DispatchQueue.lyricsDisplay.async { [weak self] in
+                guard let self = self else { return }
+                self.pendingDisplayPreferenceRefresh = false
+                self.invalidateDisplayedLine()
+                self.handleLyricsDisplay()
+            }
+        }
+    }
+
+    private func invalidateDisplayedLine() {
+        lastShowingKey = nil
+        lastRenderedPlaybackState = nil
+        lastRenderedWallclock = nil
+    }
+
+    private func clearDisplayedLyricsIfNeeded() {
+        lastShowingKey = nil
+        guard hasDisplayedLyrics else { return }
+        hasDisplayedLyrics = false
+        DispatchQueue.main.async {
+            self.lyricsView.displayLrc("", secondLine: "")
+        }
+    }
+
     @objc private func handleLyricsDisplay() {
+        handleLyricsDisplay(playbackState: selectedPlayer.playbackState)
+    }
+
+    private func handleLyricsDisplay(playbackState: PlaybackState) {
+        let isPlaying = playbackState.isPlaying
         guard defaults[.desktopLyricsEnabled],
-              !defaults[.disableLyricsWhenPaused] || selectedPlayer.playbackState.isPlaying,
+              !defaults[.disableLyricsWhenPaused] || isPlaying,
               let lyrics = AppController.shared.currentLyrics,
               let index = AppController.shared.currentLineIndex else {
-            DispatchQueue.main.async {
-                self.lyricsView.displayLrc("", secondLine: "")
-            }
+            lastRenderedPlaybackState = nil
+            lastRenderedWallclock = nil
+            clearDisplayedLyricsIfNeeded()
             return
         }
+
+        // Re-anchor the progress animation only when playback actually
+        // jumps. We extrapolate the previous state forward by wallclock
+        // (linear when playing, frozen when paused) and treat any drift
+        // beyond ~80ms as a real seek/buffer/wrap-around — which is when
+        // the animation needs to be re-installed against a fresh anchor.
+        // Linear playback inside a single line stays anchored, so the
+        // running keyframe animation continues uninterrupted, and the
+        // highlight tracks playback to within the jump threshold (vs.
+        // up to 0.5s of drift previously).
+        let didJump: Bool
+        if let lastState = lastRenderedPlaybackState, let lastWall = lastRenderedWallclock {
+            let elapsed = Date().timeIntervalSince(lastWall)
+            let predicted: TimeInterval
+            switch lastState {
+            case .playing:
+                predicted = lastState.time
+            case .fastForwarding(let time):
+                predicted = time + elapsed
+            case .rewinding(let time):
+                predicted = time - elapsed
+            case .paused(let time):
+                predicted = time
+            case .stopped:
+                predicted = 0
+            }
+            didJump = abs(playbackState.time - predicted) > 0.08
+        } else {
+            didJump = true
+        }
+        let trackDuration = selectedPlayer.currentTrack?.duration
+        let key = DisplayKey(
+            lyricsId: ObjectIdentifier(lyrics),
+            lineIndex: index,
+            isPlaying: isPlaying,
+            preferBilingual: defaults[.preferBilingualLyrics],
+            oneLineMode: defaults[.desktopLyricsOneLineMode],
+            chineseConversionIndex: defaults[.chineseConversionIndex],
+            timeDelayMs: Int((lyrics.adjustedTimeDelay * 1000).rounded())
+        )
+        if lastShowingKey == key && !didJump {
+            return
+        }
+        lastShowingKey = key
+        lastRenderedPlaybackState = playbackState
+        lastRenderedWallclock = Date()
+        hasDisplayedLyrics = true
 
         let lrc = lyrics.lines[index]
         let next = lyrics.lines[(index + 1)...].first { $0.enabled }
@@ -148,15 +299,23 @@ class KaraokeLyricsWindowController: NSWindowController {
             }
         }
 
+        // Capture the offset on `lyricsDisplay` so the progress animation
+        // below is computed against the same lyrics that produced `lrc`
+        // and `index`. Re-reading `AppController.shared.currentLyrics`
+        // inside the `main.async` block would race with track switching
+        // and could mix the old line with the new song's offset.
+        let timeDelay = lyrics.adjustedTimeDelay
         DispatchQueue.main.async {
             self.lyricsView.displayLrc(firstLine, secondLine: secondLine)
             if let upperTextField = self.lyricsView.displayLine1,
                let timetag = lrc.attachments.timetag {
-                let position = selectedPlayer.playbackTime
-                let timeDelay = AppController.shared.currentLyrics?.adjustedTimeDelay ?? 0
+                // Anchor on the PlaybackState that triggered this render so the
+                // animation is not seeded from a stale `selectedPlayer.playbackTime`
+                // around repeat-one wrap or track-change boundaries.
+                let position = playbackState.lyricsDisplayTime(trackDuration: trackDuration)
                 let progress = timetag.tags.map { ($0.time + lrc.position - timeDelay - position, $0.index) }
                 upperTextField.setProgressAnimation(color: self.lyricsView.progressColor, progress: progress)
-                if !selectedPlayer.playbackState.isPlaying {
+                if !isPlaying {
                     upperTextField.pauseProgressAnimation()
                 }
             }

--- a/LyricsX/Controller/KaraokeLyricsController.swift
+++ b/LyricsX/Controller/KaraokeLyricsController.swift
@@ -118,7 +118,7 @@ class KaraokeLyricsWindowController: NSWindowController {
     private static let displayRefreshPreferenceKeys: [UserDefaults.DefaultsKeys] = [
         .desktopLyricsEnabled,
         .disableLyricsWhenPaused,
-        .preferBilingualLyrics,
+        .showTranslation,
         .desktopLyricsOneLineMode,
         .chineseConversionIndex,
         .globalLyricsOffset,
@@ -145,7 +145,7 @@ class KaraokeLyricsWindowController: NSWindowController {
         let lyricsId: ObjectIdentifier
         let lineIndex: Int
         let isPlaying: Bool
-        let preferBilingual: Bool
+        let showTranslation: Bool
         let oneLineMode: Bool
         let chineseConversionIndex: Int
         // Quantized to ms so floating-point equality is stable. The
@@ -256,7 +256,7 @@ class KaraokeLyricsWindowController: NSWindowController {
             lyricsId: ObjectIdentifier(lyrics),
             lineIndex: index,
             isPlaying: isPlaying,
-            preferBilingual: defaults[.preferBilingualLyrics],
+            showTranslation: defaults[.showTranslation],
             oneLineMode: defaults[.desktopLyricsOneLineMode],
             chineseConversionIndex: defaults[.chineseConversionIndex],
             timeDelayMs: Int((lyrics.adjustedTimeDelay * 1000).rounded())
@@ -279,7 +279,7 @@ class KaraokeLyricsWindowController: NSWindowController {
         var secondLineIsTranslation = false
         if defaults[.desktopLyricsOneLineMode] {
             secondLine = ""
-        } else if defaults[.preferBilingualLyrics],
+        } else if defaults[.showTranslation],
                   let translation = lrc.attachments[.translation(languageCode: languageCode)] {
             secondLine = translation
             secondLineIsTranslation = true

--- a/LyricsX/TouchBar/TouchBarLyricsItem.swift
+++ b/LyricsX/TouchBar/TouchBarLyricsItem.swift
@@ -45,13 +45,18 @@ class TouchBarLyricsItem: NSCustomTouchBarItem {
            lyrics.metadata.language?.hasPrefix("zh") == true {
             lyricsContent = converter.convert(lyricsContent)
         }
+        let playbackState = selectedPlayer.playbackState
+        let trackDuration = selectedPlayer.currentTrack?.duration
+        let timeDelay = lyrics.adjustedTimeDelay
+        let position = playbackState.lyricsDisplayTime(trackDuration: trackDuration)
         DispatchQueue.main.async {
             self.lyricsTextField.stringValue = lyricsContent
             if let timetag = line.attachments.timetag {
-                let position = selectedPlayer.playbackTime
-                let timeDelay = line.lyrics?.adjustedTimeDelay ?? 0
                 let progress = timetag.tags.map { ($0.time + line.position - timeDelay - position, $0.index) }
                 self.lyricsTextField.setProgressAnimation(color: self.progressColor, progress: progress)
+                if !playbackState.isPlaying {
+                    self.lyricsTextField.pauseProgressAnimation()
+                }
             }
         }
     }

--- a/LyricsX/Utility/Extension.swift
+++ b/LyricsX/Utility/Extension.swift
@@ -26,6 +26,23 @@ extension MusicPlayerName {
     }
 }
 
+extension PlaybackState {
+    static var lyricsRepeatWrapGracePeriod: TimeInterval { 0.5 }
+
+    func lyricsDisplayTime(trackDuration: TimeInterval?) -> TimeInterval {
+        let playbackTime = time
+        guard isPlaying,
+              playbackTime.isFinite,
+              let trackDuration = trackDuration,
+              trackDuration.isFinite,
+              trackDuration > 0,
+              playbackTime >= trackDuration + Self.lyricsRepeatWrapGracePeriod else {
+            return playbackTime
+        }
+        return playbackTime.truncatingRemainder(dividingBy: trackDuration)
+    }
+}
+
 extension MusicTrack {
     var lyrics: String? {
         guard let originalTrack = originalTrack,

--- a/LyricsX/Utility/Global.swift
+++ b/LyricsX/Utility/Global.swift
@@ -86,7 +86,7 @@ extension UserDefaults.DefaultsKeys {
     static let selectedLanguage = Key<String?>("SelectedLanguage")
 
     static let strictSearchEnabled = Key<Bool>("StrictSearchEnabled")
-    static let preferBilingualLyrics = Key<Bool>("PreferBilingualLyrics")
+    static let showTranslation = Key<Bool>("PreferBilingualLyrics")
     static let chineseConversionIndex = Key<Int>("ChineseConversionIndex")
 
     static let combinedMenubarLyrics = Key<Bool>("CombinedMenubarLyrics")

--- a/LyricsX/View/ScrollLyricsView.swift
+++ b/LyricsX/View/ScrollLyricsView.swift
@@ -65,7 +65,7 @@ class ScrollLyricsView: NSScrollView {
 
         for line in enabledLrc {
             var lineStr = line.content
-            if var trans = line.attachments[.translation(languageCode: languageCode)], defaults[.preferBilingualLyrics],
+            if var trans = line.attachments[.translation(languageCode: languageCode)], defaults[.showTranslation],
                languageCode?.hasPrefix("zh") == true {
                 if let converter = ChineseConverter.shared {
                     trans = converter.convert(trans)

--- a/LyricsX/bi.lproj/Preferences.strings
+++ b/LyricsX/bi.lproj/Preferences.strings
@@ -55,8 +55,8 @@
 /* Class = "NSTextFieldCell"; title = "Decrease lyrics offset:"; ObjectID = "bmk-rW-Uot"; */
 "bmk-rW-Uot.title" = "Decrease lyrics offset:";
 
-/* Class = "NSButtonCell"; title = "Prefer bilingual lyrics"; ObjectID = "cBB-zn-Hdh"; */
-"cBB-zn-Hdh.title" = "Prefer bilingual lyrics";
+/* Class = "NSButtonCell"; title = "Show translation"; ObjectID = "cBB-zn-Hdh"; */
+"cBB-zn-Hdh.title" = "Show translation";
 
 /* Class = "NSTextFieldCell"; title = "Font:"; ObjectID = "Cmt-it-PXW"; */
 "Cmt-it-PXW.title" = "Font:";
@@ -238,8 +238,8 @@
 /* Class = "NSTextFieldCell"; title = "Decrease lyrics offset:"; ObjectID = "K3n-xg-phu"; */
 "K3n-xg-phu.title" = "Decrease lyrics offset:";
 
-/* Class = "NSButtonCell"; title = "Prefer bilingual lyrics"; ObjectID = "KJ9-qG-viC"; */
-"KJ9-qG-viC.title" = "Prefer bilingual lyrics";
+/* Class = "NSButtonCell"; title = "Show translation"; ObjectID = "KJ9-qG-viC"; */
+"KJ9-qG-viC.title" = "Show translation";
 
 /* Class = "NSMenuItem"; title = "No Conversion"; ObjectID = "KR4-Qt-DFi"; */
 "KR4-Qt-DFi.title" = "No Conversion";

--- a/LyricsX/es.lproj/Perference.strings
+++ b/LyricsX/es.lproj/Perference.strings
@@ -88,8 +88,8 @@
 /* Class = "NSTextFieldCell"; title = "Decrease lyrics offset:"; ObjectID = "bmk-rW-Uot"; */
 "bmk-rW-Uot.title" = "Decremento el offset de la letra:";
 
-/* Class = "NSButtonCell"; title = "Prefer bilingual lyrics"; ObjectID = "cBB-zn-Hdh"; */
-"cBB-zn-Hdh.title" = "Prefiero letras bilingües";
+/* Class = "NSButtonCell"; title = "Show translation"; ObjectID = "cBB-zn-Hdh"; */
+"cBB-zn-Hdh.title" = "Show translation";
 
 /* Class = "NSViewController"; title = "General"; ObjectID = "d5d-dC-DK4"; */
 "d5d-dC-DK4.title" = "General";

--- a/LyricsX/fr.lproj/Perference.strings
+++ b/LyricsX/fr.lproj/Perference.strings
@@ -88,8 +88,8 @@
 /* Class = "NSTextFieldCell"; title = "Decrease lyrics offset:"; ObjectID = "bmk-rW-Uot"; */
 "bmk-rW-Uot.title" = "Decrease lyrics offset:";
 
-/* Class = "NSButtonCell"; title = "Prefer bilingual lyrics"; ObjectID = "cBB-zn-Hdh"; */
-"cBB-zn-Hdh.title" = "Prefer bilingual lyrics";
+/* Class = "NSButtonCell"; title = "Show translation"; ObjectID = "cBB-zn-Hdh"; */
+"cBB-zn-Hdh.title" = "Show translation";
 
 /* Class = "NSViewController"; title = "General"; ObjectID = "d5d-dC-DK4"; */
 "d5d-dC-DK4.title" = "General";

--- a/LyricsX/hr.lproj/Preferences.strings
+++ b/LyricsX/hr.lproj/Preferences.strings
@@ -55,8 +55,8 @@
 /* Class = "NSTextFieldCell"; title = "Decrease lyrics offset:"; ObjectID = "bmk-rW-Uot"; */
 "bmk-rW-Uot.title" = "Povećaj odstupanje stihova:";
 
-/* Class = "NSButtonCell"; title = "Prefer bilingual lyrics"; ObjectID = "cBB-zn-Hdh"; */
-"cBB-zn-Hdh.title" = "Draže su mi višejezični stihovi";
+/* Class = "NSButtonCell"; title = "Show translation"; ObjectID = "cBB-zn-Hdh"; */
+"cBB-zn-Hdh.title" = "Show translation";
 
 /* Class = "NSTextFieldCell"; title = "Font:"; ObjectID = "Cmt-it-PXW"; */
 "Cmt-it-PXW.title" = "Font:";
@@ -238,8 +238,8 @@
 /* Class = "NSTextFieldCell"; title = "Decrease lyrics offset:"; ObjectID = "K3n-xg-phu"; */
 "K3n-xg-phu.title" = "Decrease lyrics offset:";
 
-/* Class = "NSButtonCell"; title = "Prefer bilingual lyrics"; ObjectID = "KJ9-qG-viC"; */
-"KJ9-qG-viC.title" = "Prefer bilingual lyrics";
+/* Class = "NSButtonCell"; title = "Show translation"; ObjectID = "KJ9-qG-viC"; */
+"KJ9-qG-viC.title" = "Show translation";
 
 /* Class = "NSMenuItem"; title = "No Conversion"; ObjectID = "KR4-Qt-DFi"; */
 "KR4-Qt-DFi.title" = "No Conversion";

--- a/LyricsX/mul.lproj/Preferences.xcstrings
+++ b/LyricsX/mul.lproj/Preferences.xcstrings
@@ -3530,115 +3530,115 @@
       }
     },
     "cBB-zn-Hdh.title" : {
-      "comment" : "Class = \"NSButtonCell\"; title = \"Prefer bilingual lyrics\"; ObjectID = \"cBB-zn-Hdh\";",
+      "comment" : "Class = \"NSButtonCell\"; title = \"Show translation\"; ObjectID = \"cBB-zn-Hdh\";",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "تفضيل كلمات الأغاني ثنائية اللغة"
+            "state" : "new",
+            "value" : "Show translation"
           }
         },
         "base" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Prefer bilingual lyrics"
+            "value" : "Show translation"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zweisprachige Songtexte bevorzugen"
+            "state" : "new",
+            "value" : "Show translation"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Prefer bilingual lyrics"
+            "value" : "Show translation"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prefiero letras bilingües"
+            "state" : "new",
+            "value" : "Show translation"
           }
         },
         "fa" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "نمایش متن ترانه دو زبانه (در صورت وجود)"
+            "state" : "new",
+            "value" : "Show translation"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Préférer les paroles bilingues"
+            "state" : "new",
+            "value" : "Show translation"
           }
         },
         "id" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lebih suka lirik dwibahasa"
+            "state" : "new",
+            "value" : "Show translation"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preferisci testo bilingue"
+            "state" : "new",
+            "value" : "Show translation"
           }
         },
         "ja" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "バイリンガルの歌詞を優先する"
+            "state" : "new",
+            "value" : "Show translation"
           }
         },
         "ko" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "이중 언어 표시하기"
+            "state" : "new",
+            "value" : "Show translation"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Liever tweetalige songteksten"
+            "state" : "new",
+            "value" : "Show translation"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preferuj dwu-języczne teksty"
+            "state" : "new",
+            "value" : "Show translation"
           }
         },
         "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preferir letras bilíngues"
+            "state" : "new",
+            "value" : "Show translation"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Предпочитать двуязычные тексты"
+            "state" : "new",
+            "value" : "Show translation"
           }
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Віддавати перевагу двомовним текстам"
+            "state" : "new",
+            "value" : "Show translation"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "优先使用双语歌词"
+            "value" : "显示译文"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "優先使用雙語歌詞"
+            "value" : "顯示譯文"
           }
         }
       }
@@ -7574,115 +7574,115 @@
       }
     },
     "KJ9-qG-viC.title" : {
-      "comment" : "Class = \"NSButtonCell\"; title = \"Prefer bilingual lyrics\"; ObjectID = \"KJ9-qG-viC\";",
+      "comment" : "Class = \"NSButtonCell\"; title = \"Show translation\"; ObjectID = \"KJ9-qG-viC\";",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "تفضيل كلمات الأغاني ثنائية اللغة"
+            "state" : "new",
+            "value" : "Show translation"
           }
         },
         "base" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Prefer bilingual lyrics"
+            "value" : "Show translation"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zweisprachige Songtexte bevorzugen"
+            "state" : "new",
+            "value" : "Show translation"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Prefer bilingual lyrics"
+            "value" : "Show translation"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prefiero letras bilingües"
+            "state" : "new",
+            "value" : "Show translation"
           }
         },
         "fa" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "نمایش متن ترانه دو زبانه (در صورت وجود)"
+            "state" : "new",
+            "value" : "Show translation"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Préférer les paroles bilingues"
+            "state" : "new",
+            "value" : "Show translation"
           }
         },
         "id" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lebih suka lirik dwibahasa"
+            "state" : "new",
+            "value" : "Show translation"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preferisci testo bilingue"
+            "state" : "new",
+            "value" : "Show translation"
           }
         },
         "ja" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "バイリンガルの歌詞を優先する"
+            "state" : "new",
+            "value" : "Show translation"
           }
         },
         "ko" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "이중 언어 표시하기"
+            "state" : "new",
+            "value" : "Show translation"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Liever tweetalige songteksten"
+            "state" : "new",
+            "value" : "Show translation"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preferuj dwu-języczne teksty"
+            "state" : "new",
+            "value" : "Show translation"
           }
         },
         "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preferir letras bilíngues"
+            "state" : "new",
+            "value" : "Show translation"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Предпочитать двуязычные тексты"
+            "state" : "new",
+            "value" : "Show translation"
           }
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Віддавати перевагу двомовним текстам"
+            "state" : "new",
+            "value" : "Show translation"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "优先使用双语歌词"
+            "value" : "显示译文"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "優先使用雙語歌詞"
+            "value" : "顯示譯文"
           }
         }
       }

--- a/LyricsX/zh-Hant.lproj/Perference.strings
+++ b/LyricsX/zh-Hant.lproj/Perference.strings
@@ -88,8 +88,8 @@
 /* Class = "NSTextFieldCell"; title = "Decrease lyrics offset:"; ObjectID = "bmk-rW-Uot"; */
 "bmk-rW-Uot.title" = "延遲顯示歌詞：";
 
-/* Class = "NSButtonCell"; title = "Prefer bilingual lyrics"; ObjectID = "cBB-zn-Hdh"; */
-"cBB-zn-Hdh.title" = "優先使用雙語歌詞";
+/* Class = "NSButtonCell"; title = "Show translation"; ObjectID = "cBB-zn-Hdh"; */
+"cBB-zn-Hdh.title" = "顯示譯文";
 
 /* Class = "NSViewController"; title = "General"; ObjectID = "d5d-dC-DK4"; */
 "d5d-dC-DK4.title" = "一般";


### PR DESCRIPTION
“优先使用双语歌词”开关只在显示侧被读取，但其名称会让人误以为它会影响搜索结果。更改名称为“显示译文”，从而表明其只是一个显示层的开关，而没有“倾向”。

关于翻译：UserDefaults 磁盘 key 字符串 "PreferBilingualLyrics" 为使老用户直接继承，保持不变。zh-Hans / zh-Hant / en 已翻译；其余 14个 locale 重置为 state=new + 英文源。

fix #104
不过 #104 反馈的问题“不会匹配双语歌词”看上去在程序逻辑上是没有问题的，因为这个开关不会影响任何搜索歌词和匹配机制。搜不到应该是单纯的匹配机制问题，和这个开关没关系