### PR TITLE
Prefer source kana for furigana display

### DIFF
--- a/LyricsX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/LyricsX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -222,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Mx-Iris/UIFoundation",
       "state" : {
-        "revision" : "a1fc98293da7f4c7744fc70e23cecb0417eb5574",
-        "version" : "0.4.0"
+        "revision" : "36dc65d71b0f27a3ec3e7576f56703275d4f02af",
+        "version" : "0.10.2"
       }
     }
   ],

--- a/LyricsX/Base.lproj/Preferences.storyboard
+++ b/LyricsX/Base.lproj/Preferences.storyboard
@@ -1493,6 +1493,7 @@
                                     <gridRow yPlacement="center" height="20" id="HwQ-Go-InK"/>
                                     <gridRow yPlacement="center" height="20" id="aXA-4O-lyR"/>
                                     <gridRow yPlacement="center" height="25" id="qxK-7k-u6w"/>
+                                    <gridRow yPlacement="center" height="25" id="source-Kana-Row"/>
                                     <gridRow yPlacement="center" height="25" id="new-Romajin-Row"/>
                                     <gridRow yPlacement="center" height="20" id="es4-R9-etL"/>
                                     <gridRow yPlacement="center" height="20" id="6GV-2W-Qb0"/>
@@ -1559,6 +1560,20 @@
                                             </buttonCell>
                                             <connections>
                                                 <binding destination="DdU-cn-wN1" name="value" keyPath="values.DesktopLyricsEnableFurigana" id="eep-JT-q3f"/>
+                                            </connections>
+                                        </button>
+                                    </gridCell>
+                                    <gridCell row="source-Kana-Row" column="8ba-lF-U7s" id="source-Kana-Left"/>
+                                    <gridCell row="source-Kana-Row" column="4uA-B7-Dvh" id="source-Kana-Right">
+                                        <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="source-Kana-Button">
+                                            <rect key="frame" x="170" y="372" width="259" height="16"/>
+                                            <buttonCell key="cell" type="check" title="Use source-provided kana when available" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="source-Kana-Cell">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                            </buttonCell>
+                                            <connections>
+                                                <binding destination="DdU-cn-wN1" name="value" keyPath="values.DesktopLyricsUseSourceKana" id="source-Kana-Binding"/>
+                                                <binding destination="DdU-cn-wN1" name="enabled" keyPath="values.DesktopLyricsEnableFurigana" id="source-Kana-Enabled"/>
                                             </connections>
                                         </button>
                                     </gridCell>

--- a/LyricsX/Component/AppController.swift
+++ b/LyricsX/Component/AppController.swift
@@ -340,6 +340,7 @@ final class AppController: NSObject {
                     if lyrics.metadata.artist == nil || lyrics.metadata.artist?.isEmpty == true {
                         lyrics.metadata.artist = artist
                     }
+                    lyrics.applyQQMusicKanaFurigana()
                     lyrics.filtrate()
                     lyrics.recognizeLanguage()
                     currentLyrics = lyrics
@@ -380,6 +381,7 @@ final class AppController: NSObject {
                 lyrics.metadata.localURL = url
                 lyrics.metadata.title = title
                 lyrics.metadata.artist = artist
+                lyrics.applyQQMusicKanaFurigana()
                 lyrics.filtrate()
                 lyrics.recognizeLanguage()
                 currentLyrics = lyrics
@@ -479,6 +481,7 @@ final class AppController: NSObject {
         }
 
         lyrics.associateWithTrack(track)
+        lyrics.applyQQMusicKanaFurigana()
         lyrics.filtrate()
         lyrics.recognizeLanguage()
         lyrics.metadata.needsPersist = true
@@ -662,6 +665,7 @@ extension AppController {
         }
         lrc.metadata.title = track.title
         lrc.metadata.artist = track.artist
+        lrc.applyQQMusicKanaFurigana()
         lrc.filtrate()
         lrc.recognizeLanguage()
         lrc.metadata.needsPersist = true

--- a/LyricsX/Controller/KaraokeLyricsController.swift
+++ b/LyricsX/Controller/KaraokeLyricsController.swift
@@ -74,6 +74,7 @@ class KaraokeLyricsWindowController: NSWindowController {
         lyricsView.bind(\.backgroundColor, withDefaultName: .desktopLyricsBackgroundColor)
         lyricsView.bind(\.isVertical, withDefaultName: .desktopLyricsVerticalMode, options: [.nullPlaceholder: false])
         lyricsView.bind(\.drawFurigana, withDefaultName: .desktopLyricsEnableFurigana, options: [.nullPlaceholder: false])
+        lyricsView.bind(\.useSourceFurigana, withDefaultName: .desktopLyricsUseSourceKana, options: [.nullPlaceholder: true])
         lyricsView.bind(\.drawRomajin, withDefaultName: .desktopLyricsEnableRomajin, options: [.nullPlaceholder: false])
 
         let negateOption = [NSBindingOption.valueTransformerName: NSValueTransformerName.negateBooleanTransformerName]
@@ -124,6 +125,7 @@ class KaraokeLyricsWindowController: NSWindowController {
         .globalLyricsOffset,
         .desktopLyricsVerticalMode,
         .desktopLyricsEnableFurigana,
+        .desktopLyricsUseSourceKana,
         .desktopLyricsEnableRomajin,
         .desktopLyricsFontName,
         .desktopLyricsFontSize,
@@ -271,11 +273,13 @@ class KaraokeLyricsWindowController: NSWindowController {
 
         let lrc = lyrics.lines[index]
         let next = lyrics.lines[(index + 1)...].first { $0.enabled }
+        let firstLineFurigana = lrc.attachments.furigana
 
         let languageCode = lyrics.metadata.translationLanguages.first
 
         var firstLine = lrc.content
         var secondLine: String
+        var secondLineFurigana: LyricsLine.Attachments.RangeAttribute?
         var secondLineIsTranslation = false
         if defaults[.desktopLyricsOneLineMode] {
             secondLine = ""
@@ -285,6 +289,7 @@ class KaraokeLyricsWindowController: NSWindowController {
             secondLineIsTranslation = true
         } else {
             secondLine = next?.content ?? ""
+            secondLineFurigana = next?.attachments.furigana
         }
 
         if let converter = ChineseConverter.shared {
@@ -306,7 +311,12 @@ class KaraokeLyricsWindowController: NSWindowController {
         // and could mix the old line with the new song's offset.
         let timeDelay = lyrics.adjustedTimeDelay
         DispatchQueue.main.async {
-            self.lyricsView.displayLrc(firstLine, secondLine: secondLine)
+            self.lyricsView.displayLrc(
+                firstLine,
+                secondLine: secondLine,
+                firstLineFurigana: firstLineFurigana,
+                secondLineFurigana: secondLineFurigana
+            )
             if let upperTextField = self.lyricsView.displayLine1,
                let timetag = lrc.attachments.timetag {
                 // Anchor on the PlaybackState that triggered this render so the

--- a/LyricsX/Controller/MenuBarLyricsController.swift
+++ b/LyricsX/Controller/MenuBarLyricsController.swift
@@ -38,7 +38,7 @@ final class MenuBarLyricsController {
 
     private lazy var contentStackView = HStackView(
         distribution: .fill,
-        alignment: .centerY,
+        alignment: .center,
         spacing: 4
     ) {
         marqueeLabel

--- a/LyricsX/Supporting Files/UserDefaults.plist
+++ b/LyricsX/Supporting Files/UserDefaults.plist
@@ -18,6 +18,8 @@
 	<integer>20</integer>
 	<key>DesktopLyricsEnableFurigana</key>
 	<false/>
+	<key>DesktopLyricsUseSourceKana</key>
+	<true/>
 	<key>DesktopLyricsFontName</key>
 	<string>Optima-Regular</string>
 	<key>DesktopLyricsFontSize</key>

--- a/LyricsX/Utility/Global.swift
+++ b/LyricsX/Utility/Global.swift
@@ -108,6 +108,7 @@ extension UserDefaults.DefaultsKeys {
     static let desktopLyricsYPositionFactor = Key<CGFloat>("DesktopLyricsYPositionFactor")
 
     static let desktopLyricsEnableFurigana = Key<Bool>("DesktopLyricsEnableFurigana")
+    static let desktopLyricsUseSourceKana = Key<Bool>("DesktopLyricsUseSourceKana")
     static let desktopLyricsEnableRomajin = Key<Bool>("DesktopLyricsEnableRomajin")
 
     static let desktopLyricsFontName = Key<String>("DesktopLyricsFontName")

--- a/LyricsX/View/KaraokeLabel.swift
+++ b/LyricsX/View/KaraokeLabel.swift
@@ -1,5 +1,6 @@
 import Cocoa
 import SwiftCF
+import LyricsXFoundation
 import CoreGraphicsExt
 import CoreTextExt
 
@@ -18,7 +19,21 @@ class KaraokeLabel: NSTextField {
         }
     }
 
+    @objc dynamic var useSourceFurigana = true {
+        didSet {
+            clearCache()
+            invalidateIntrinsicContentSize()
+        }
+    }
+
     @objc dynamic var drawRomajin = false {
+        didSet {
+            clearCache()
+            invalidateIntrinsicContentSize()
+        }
+    }
+
+    var sourceFurigana: LyricsLine.Attachments.RangeAttribute? {
         didSet {
             clearCache()
             invalidateIntrinsicContentSize()
@@ -65,9 +80,13 @@ class KaraokeLabel: NSTextField {
             return attrString
         }
         let attrString = NSMutableAttributedString(attributedString: attributedStringValue)
+        let content = attrString.string
         let string = attrString.string as NSString
         let shouldDrawFurigana = drawFurigana && string.dominantLanguage == "ja"
         let shouldDrawRomajin = drawRomajin && string.dominantLanguage == "ja"
+        let didApplySourceFurigana = shouldDrawFurigana
+            && useSourceFurigana
+            && sourceFurigana.map { addSourceFurigana($0, to: attrString, content: content) } == true
         let tokenizer = CFStringTokenizer.create(string: .from(string))
         romajinAnnotations = []
         for tokenType in IteratorSequence(tokenizer) where tokenType.contains(.isCJWordMask) {
@@ -79,8 +98,8 @@ class KaraokeLabel: NSTextField {
                 ]
                 attrString.addAttributes(attr, range: tokenRange.asNS)
             }
-            guard shouldDrawFurigana else { continue }
-            if let (furigana, range) = tokenizer.currentFuriganaAnnotation(in: string) {
+            if shouldDrawFurigana && !didApplySourceFurigana,
+               let (furigana, range) = tokenizer.currentFuriganaAnnotation(in: string) {
                 var attr: [CFAttributedString.Key: Any] = [.ctRubySizeFactor: 0.5]
                 attr[.ctForegroundColor] = textColor
                 let annotation = CTRubyAnnotation.create(furigana, attributes: attr)
@@ -93,6 +112,25 @@ class KaraokeLabel: NSTextField {
         textColor?.do { attrString.addAttributes([.foregroundColor: $0], range: attrString.fullRange) }
         _attrString = attrString
         return attrString
+    }
+
+    private func addSourceFurigana(
+        _ sourceFurigana: LyricsLine.Attachments.RangeAttribute,
+        to attrString: NSMutableAttributedString,
+        content: String
+    ) -> Bool {
+        var didApply = false
+        for attribute in sourceFurigana.attributes {
+            guard let range = content.nsRange(fromCharacterRange: attribute.range) else {
+                continue
+            }
+            var attr: [CFAttributedString.Key: Any] = [.ctRubySizeFactor: 0.5]
+            attr[.ctForegroundColor] = textColor
+            let annotation = CTRubyAnnotation.create(attribute.content as CFString, attributes: attr)
+            attrString.addAttribute(.cf(.ctRubyAnnotation), value: annotation, range: range)
+            didApply = true
+        }
+        return didApply
     }
 
     private var _ctFrame: CTFrame?
@@ -371,5 +409,17 @@ class KaraokeLabel: NSTextField {
             }
             annotationIndex += 1
         }
+    }
+}
+
+private extension String {
+    func nsRange(fromCharacterRange range: Range<Int>) -> NSRange? {
+        guard range.lowerBound >= 0,
+              range.upperBound <= count else {
+            return nil
+        }
+        let lowerBound = index(startIndex, offsetBy: range.lowerBound)
+        let upperBound = index(startIndex, offsetBy: range.upperBound)
+        return NSRange(lowerBound ..< upperBound, in: self)
     }
 }

--- a/LyricsX/View/KaraokeLyricsView.swift
+++ b/LyricsX/View/KaraokeLyricsView.swift
@@ -1,4 +1,5 @@
 import AppKit
+import LyricsXFoundation
 import SnapKit
 
 class KaraokeLyricsView: NSView {
@@ -14,6 +15,7 @@ class KaraokeLyricsView: NSView {
     }
 
     @objc dynamic var drawFurigana = false
+    @objc dynamic var useSourceFurigana = true
     @objc dynamic var drawRomajin = false
 
     @objc dynamic var font = NSFont.labelFont(ofSize: 24) { didSet { updateFontSize() } }
@@ -67,10 +69,11 @@ class KaraokeLyricsView: NSView {
         backgroundView.layer?.cornerRadius = font.pointSize / 2
     }
 
-    private func lyricsLabel(_ content: String) -> KaraokeLabel {
+    private func lyricsLabel(_ content: String, sourceFurigana: LyricsLine.Attachments.RangeAttribute?) -> KaraokeLabel {
         if let view = stackView.subviews.lazy.compactMap({ $0 as? KaraokeLabel }).first(where: { !stackView.arrangedSubviews.contains($0) }) {
             view.alphaValue = 0
             view.stringValue = content
+            view.sourceFurigana = sourceFurigana
             view.removeProgressAnimation()
             view.removeFromSuperview()
             return view
@@ -82,12 +85,19 @@ class KaraokeLyricsView: NSView {
             $0.bind(\._shadowColor, to: self, withKeyPath: \.shadowColor)
             $0.bind(\.isVertical, to: self, withKeyPath: \.isVertical)
             $0.bind(\.drawFurigana, to: self, withKeyPath: \.drawFurigana)
+            $0.bind(\.useSourceFurigana, to: self, withKeyPath: \.useSourceFurigana)
             $0.bind(\.drawRomajin, to: self, withKeyPath: \.drawRomajin)
+            $0.sourceFurigana = sourceFurigana
             $0.alphaValue = 0
         }
     }
 
-    func displayLrc(_ firstLine: String, secondLine: String = "") {
+    func displayLrc(
+        _ firstLine: String,
+        secondLine: String = "",
+        firstLineFurigana: LyricsLine.Attachments.RangeAttribute? = nil,
+        secondLineFurigana: LyricsLine.Attachments.RangeAttribute? = nil
+    ) {
         var toBeHide = stackView.arrangedSubviews.compactMap { $0 as? KaraokeLabel }
         var toBeShow: [NSTextField] = []
         var shouldHideAll = false
@@ -98,15 +108,16 @@ class KaraokeLyricsView: NSView {
             shouldHideAll = true
         } else if toBeHide.count == 2, toBeHide[index].stringValue == firstLine {
             displayLine1 = toBeHide[index]
+            displayLine1?.sourceFurigana = firstLineFurigana
             toBeHide.remove(at: index)
         } else {
-            let label = lyricsLabel(firstLine)
+            let label = lyricsLabel(firstLine, sourceFurigana: firstLineFurigana)
             displayLine1 = label
             toBeShow.append(label)
         }
 
         if !secondLine.trimmingCharacters(in: .whitespaces).isEmpty {
-            let label = lyricsLabel(secondLine)
+            let label = lyricsLabel(secondLine, sourceFurigana: secondLineFurigana)
             displayLine2 = label
             toBeShow.append(label)
         } else {

--- a/LyricsX/mul.lproj/Preferences.xcstrings
+++ b/LyricsX/mul.lproj/Preferences.xcstrings
@@ -9367,6 +9367,36 @@
         }
       }
     },
+    "source-Kana-Cell.title" : {
+      "comment" : "Class = \"NSButtonCell\"; title = \"Use source-provided kana when available\"; ObjectID = \"source-Kana-Cell\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "base" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use source-provided kana when available"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use source-provided kana when available"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "优先使用歌词源提供的假名"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "優先使用歌詞源提供的假名"
+          }
+        }
+      }
+    },
     "new-Romajin-Cell.title" : {
       "comment" : "Class = \"NSButtonCell\"; title = \"Automatically generate romajin for Japanese lyrics\"; ObjectID = \"new-Romajin-Cell\";",
       "extractionState" : "extracted_with_value",


### PR DESCRIPTION
## Summary

- add a Lab preference to use source-provided kana when furigana is enabled
- pass LyricsKit furigana attachments through the desktop lyrics renderer
- convert cached/imported QQMusic `[kana:]` tags before filtering lyrics
- update UIFoundation resolution to match the project minimum and use the current stack alignment API

## Dependency

- Depends on MxIris-LyricsX-Project/LyricsKit#5 exposing QQMusic kana conversion for cached/imported lyrics.
- Keep this PR as draft until the dependent LyricsKit PR is merged or LyricsX can pin a LyricsKit revision/tag containing `applyQQMusicKanaFurigana()`.

## Verification

- `swift test --filter QQMusicProviderTests`
- `LYRICSX_USE_LOCAL_DEPENDENCY=1 xcodebuild -project LyricsX.xcodeproj -scheme LyricsX -configuration Debug -derivedDataPath /private/tmp/MxIrisLyricsX19SourceKanaDerivedData -clonedSourcePackagesDirPath /private/tmp/MxIrisLyricsX19SourceKanaSourcePackages -skipMacroValidation -skipPackagePluginValidation CODE_SIGNING_ALLOWED=NO build`
- Manual display check: QQMusic source kana rendered `咬ませ狗の武者震い` with `狗 -> いぬ` and `武者震い -> ハイテンション`, proving the source-kana path takes precedence over automatic furigana generation.