### PR TITLE
feat(AppleMusic): Route A syllable lyrics + TTML import

### DIFF
--- a/LyricsX/Component/AppController.swift
+++ b/LyricsX/Component/AppController.swift
@@ -90,7 +90,7 @@ final class AppController: NSObject {
         .map { (defaults[.appleMusicNameRecoveryEnabled], selectedPlayer.name) }
         .removeDuplicates(by: ==)
         .sink { [weak self] _ in
-            Task { @MainActor in self?.updateLyricsManager() }
+            Task { @MainActor in await self?.updateLyricsManager() }
         }
         .store(in: &cancelBag)
 
@@ -162,21 +162,49 @@ final class AppController: NSObject {
 
         currentTrackChanged()
 
-        Task { @MainActor in
-            updateLyricsManager()
+        Task {
+            // Prime the Apple Music amp-api session: store the user's
+            // `media-user-token`, plus any storefront / language override
+            // they pinned in preferences. The overrides are pure state
+            // bias for the provider's path-building; only `configure`
+            // triggers any network work (the lazy developer-token fetch
+            // on the next `musicAPI()` call).
+            if #available(macOS 12.0, *) {
+                if let token = defaults[.appleMusicMediaUserToken], !token.isEmpty {
+                    await AppleMusicSession.shared.configure(mediaUserToken: token)
+                }
+                if let storefront = defaults[.appleMusicStorefront], !storefront.isEmpty {
+                    await AppleMusicSession.shared.setStorefrontOverride(storefront)
+                }
+                if let language = defaults[.appleMusicLanguage], !language.isEmpty {
+                    await AppleMusicSession.shared.setLanguageOverride(language)
+                }
+            }
+            await updateLyricsManager()
         }
     }
 
     @MainActor
-    func updateLyricsManager() {
+    func updateLyricsManager() async {
         let musixmatchToken = defaults[.musixmatchToken].flatMap { $0.isEmpty ? nil : $0 }
-        let providers: [LyricsProvider] = [
+        var providers: [LyricsProvider] = [
             LyricsProviders.Service.netease.create(),
             LyricsProviders.Service.qq.create(),
             LyricsProviders.Service.kugou.create(),
             LyricsProviders.Service.lrclib.create(),
             LyricsProviders.Service.musixmatch.create(.init(usertoken: musixmatchToken)),
         ]
+        // Route A: official Apple Music syllable-lyrics via amp-api. Only
+        // registered when the user supplied a `media-user-token` AND the
+        // session can actually reach amp-api with it (the probe hits
+        // `/v1/me/storefront` once, cached per-process) — without that,
+        // every fetch would 401 and pollute the result stream.
+        if #available(macOS 12.0, *),
+           let token = defaults[.appleMusicMediaUserToken],
+           !token.isEmpty,
+           await AppleMusicSession.shared.isAuthorized() {
+            providers.append(LyricsProviders.Service.appleMusic.create())
+        }
         // Route B: for Apple Music tracks, a search plugin recovers the
         // native-script name via the Apple Music catalog so the providers
         // can match it. The plugin runs upstream of the providers — it
@@ -646,8 +674,17 @@ final class AppController: NSObject {
 }
 
 extension AppController {
-    func importLyrics(_ lyricsString: String) throws {
-        guard let lrc = Lyrics(lyricsString) else {
+    func importLyrics(_ lyricsString: String, filePath: String? = nil) throws {
+        // Pick the parser by file extension first (drag-and-drop of a `.ttml`
+        // file). For pasted text without a path, auto-detect by root element.
+        let isTTML: Bool = {
+            if let filePath {
+                return (filePath as NSString).pathExtension.lowercased() == "ttml"
+            }
+            return lyricsString.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("<tt")
+        }()
+        let parsed: Lyrics? = isTTML ? Lyrics(ttmlContent: lyricsString) : Lyrics(lyricsString)
+        guard let lrc = parsed else {
             let errorInfo = [
                 NSLocalizedDescriptionKey: "Invalid lyric file",
                 NSLocalizedRecoverySuggestionErrorKey: "Please try another one.",

--- a/LyricsX/Controller/KaraokeLyricsController.swift
+++ b/LyricsX/Controller/KaraokeLyricsController.swift
@@ -250,7 +250,12 @@ class KaraokeLyricsWindowController: NSWindowController {
                 // animation is not seeded from a stale `selectedPlayer.playbackTime`
                 // around repeat-one wrap or track-change boundaries.
                 let position = playbackState.lyricsDisplayTime(trackDuration: trackDuration)
-                let progress = timetag.tags.map { ($0.time + lrc.position - timeDelay - position, $0.index) }
+                var progress = timetag.tags.map { ($0.time + lrc.position - timeDelay - position, $0.index) }
+                // Append a final keyframe at the line's end so the last word
+                // fills progressively instead of getting stuck at its begin tag.
+                if let duration = timetag.duration, duration > 0 {
+                    progress.append((duration + lrc.position - timeDelay - position, lrc.content.count))
+                }
                 upperTextField.setProgressAnimation(color: self.lyricsView.progressColor, progress: progress)
                 if !isPlaying {
                     upperTextField.pauseProgressAnimation()

--- a/LyricsX/LyricsHUD/LyricsHUDViewController.swift
+++ b/LyricsX/LyricsHUD/LyricsHUDViewController.swift
@@ -132,9 +132,9 @@ class LyricsHUDViewController: NSViewController, NSWindowDelegate, ScrollLyricsV
 
     // MARK: DragNDropDelegate
 
-    func dragFinished(content: String) {
+    func dragFinished(content: String, filePath: String?) {
         do {
-            try AppController.shared.importLyrics(content)
+            try AppController.shared.importLyrics(content, filePath: filePath)
         } catch {
             let alert = NSAlert(error: error)
             alert.beginSheetModal(for: view.window!)

--- a/LyricsX/Preferences/PreferenceLabViewController.swift
+++ b/LyricsX/Preferences/PreferenceLabViewController.swift
@@ -13,6 +13,10 @@ class PreferenceLabViewController: PreferenceViewController {
 
     @IBOutlet var artworkSimilarityBoostButton: NSButton!
 
+    @IBOutlet weak var appleMusicMediaUserTokenField: NSTextField!
+    @IBOutlet weak var appleMusicStorefrontField: NSTextField!
+    @IBOutlet weak var appleMusicLanguageField: NSTextField!
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -50,6 +54,10 @@ class PreferenceLabViewController: PreferenceViewController {
         } else {
             musixmatchTokenField.stringValue = ""
         }
+
+        appleMusicMediaUserTokenField.stringValue = defaults[.appleMusicMediaUserToken] ?? ""
+        appleMusicStorefrontField.stringValue = defaults[.appleMusicStorefront] ?? ""
+        appleMusicLanguageField.stringValue = defaults[.appleMusicLanguage] ?? ""
     }
 
     @IBAction func musixmatchTokenChanged(_ sender: NSTextField) {
@@ -61,7 +69,56 @@ class PreferenceLabViewController: PreferenceViewController {
         }
 
         // Update lyrics manager when token changes
-        AppController.shared.updateLyricsManager()
+        Task { @MainActor in await AppController.shared.updateLyricsManager() }
+    }
+
+    // MARK: - Apple Music media-user-token / overrides
+
+    /// The user pastes their `media-user-token` (copied from Safari's
+    /// `music.apple.com` cookies). Saving it reconfigures the off-screen
+    /// web session so MusicKit on that page picks up the injected cookie.
+    @IBAction func appleMusicMediaUserTokenChanged(_ sender: NSTextField) {
+        let value = sender.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = value.isEmpty ? nil : value
+        if let trimmed {
+            defaults[.appleMusicMediaUserToken] = trimmed
+        } else {
+            defaults.remove(.appleMusicMediaUserToken)
+        }
+
+        guard #available(macOS 12.0, *) else { return }
+        Task {
+            if let trimmed {
+                await AppleMusicSession.shared.configure(mediaUserToken: trimmed)
+            } else {
+                await AppleMusicSession.shared.clearToken()
+            }
+            await AppController.shared.updateLyricsManager()
+        }
+    }
+
+    @IBAction func appleMusicStorefrontChanged(_ sender: NSTextField) {
+        let value = sender.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = value.isEmpty ? nil : value
+        if let trimmed {
+            defaults[.appleMusicStorefront] = trimmed
+        } else {
+            defaults.remove(.appleMusicStorefront)
+        }
+        guard #available(macOS 12.0, *) else { return }
+        Task { await AppleMusicSession.shared.setStorefrontOverride(trimmed) }
+    }
+
+    @IBAction func appleMusicLanguageChanged(_ sender: NSTextField) {
+        let value = sender.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = value.isEmpty ? nil : value
+        if let trimmed {
+            defaults[.appleMusicLanguage] = trimmed
+        } else {
+            defaults.remove(.appleMusicLanguage)
+        }
+        guard #available(macOS 12.0, *) else { return }
+        Task { await AppleMusicSession.shared.setLanguageOverride(trimmed) }
     }
 
     @IBAction func customizeAllowsNowPlayingApplicationsAction(_ sender: NSButton) {

--- a/LyricsX/Supporting Files/Base.lproj/Preferences.storyboard
+++ b/LyricsX/Supporting Files/Base.lproj/Preferences.storyboard
@@ -1519,6 +1519,9 @@
                                     <gridRow yPlacement="fill" topPadding="5" id="AML-Ro-W01"/>
                                     <gridRow yPlacement="fill" topPadding="5" id="ANR-Ro-W01"/>
                                     <gridRow yPlacement="fill" topPadding="5" id="ART-Ro-W01"/>
+                                    <gridRow yPlacement="fill" height="30" topPadding="5" id="AMT-Ro-W01"/>
+                                    <gridRow yPlacement="fill" height="30" topPadding="5" id="AMS-Ro-W01"/>
+                                    <gridRow yPlacement="fill" height="30" topPadding="5" id="AMG-Ro-W01"/>
                                     <gridRow yPlacement="fill" height="30" topPadding="5" id="lp0-JX-wTa"/>
                                 </rows>
                                 <columns>
@@ -1746,6 +1749,75 @@
                                             </buttonCell>
                                         </button>
                                     </gridCell>
+                                    <gridCell row="AMT-Ro-W01" column="8ba-lF-U7s" yPlacement="center" id="AMT-Ce-L01">
+                                        <textField key="contentView" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="AMT-Lb-T01">
+                                            <rect key="frame" x="0" y="0" width="150" height="16"/>
+                                            <textFieldCell key="cell" lineBreakMode="clipping" title="Apple Music Token:" id="AMT-Cl-L01">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                    </gridCell>
+                                    <gridCell row="AMT-Ro-W01" column="4uA-B7-Dvh" yPlacement="center" id="AMT-Ce-R01">
+                                        <textField key="contentView" focusRingType="none" verticalHuggingPriority="750" placeholderIntrinsicWidth="200" placeholderIntrinsicHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="AMT-Tf-N01">
+                                            <rect key="frame" x="170" y="4" width="350" height="22"/>
+                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" refusesFirstResponder="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="Paste media-user-token from music.apple.com" usesSingleLineMode="YES" bezelStyle="round" id="AMT-Cl-N01">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                            <connections>
+                                                <action selector="appleMusicMediaUserTokenChanged:" target="JPs-hn-m7d" id="AMT-Ac-N01"/>
+                                            </connections>
+                                        </textField>
+                                    </gridCell>
+                                    <gridCell row="AMS-Ro-W01" column="8ba-lF-U7s" yPlacement="center" id="AMS-Ce-L01">
+                                        <textField key="contentView" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="AMS-Lb-T01">
+                                            <rect key="frame" x="0" y="0" width="150" height="16"/>
+                                            <textFieldCell key="cell" lineBreakMode="clipping" title="Storefront:" id="AMS-Cl-L01">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                    </gridCell>
+                                    <gridCell row="AMS-Ro-W01" column="4uA-B7-Dvh" yPlacement="center" id="AMS-Ce-R01">
+                                        <textField key="contentView" focusRingType="none" verticalHuggingPriority="750" placeholderIntrinsicWidth="200" placeholderIntrinsicHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="AMS-Tf-N01">
+                                            <rect key="frame" x="170" y="4" width="200" height="22"/>
+                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" refusesFirstResponder="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="Auto-detect (e.g. cn, us, jp)" usesSingleLineMode="YES" bezelStyle="round" id="AMS-Cl-N01">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                            <connections>
+                                                <action selector="appleMusicStorefrontChanged:" target="JPs-hn-m7d" id="AMS-Ac-N01"/>
+                                            </connections>
+                                        </textField>
+                                    </gridCell>
+                                    <gridCell row="AMG-Ro-W01" column="8ba-lF-U7s" yPlacement="center" id="AMG-Ce-L01">
+                                        <textField key="contentView" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="AMG-Lb-T01">
+                                            <rect key="frame" x="0" y="0" width="150" height="16"/>
+                                            <textFieldCell key="cell" lineBreakMode="clipping" title="Lyrics Language:" id="AMG-Cl-L01">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                    </gridCell>
+                                    <gridCell row="AMG-Ro-W01" column="4uA-B7-Dvh" yPlacement="center" id="AMG-Ce-R01">
+                                        <textField key="contentView" focusRingType="none" verticalHuggingPriority="750" placeholderIntrinsicWidth="200" placeholderIntrinsicHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="AMG-Tf-N01">
+                                            <rect key="frame" x="170" y="4" width="200" height="22"/>
+                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" refusesFirstResponder="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="System default (e.g. zh-Hans, ja-JP)" usesSingleLineMode="YES" bezelStyle="round" id="AMG-Cl-N01">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                            <connections>
+                                                <action selector="appleMusicLanguageChanged:" target="JPs-hn-m7d" id="AMG-Ac-N01"/>
+                                            </connections>
+                                        </textField>
+                                    </gridCell>
                                     <gridCell row="lp0-JX-wTa" column="8ba-lF-U7s" yPlacement="center" id="YZh-w9-vzD">
                                         <textField key="contentView" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="g7i-g1-pzs">
                                             <rect key="frame" x="32" y="7" width="120" height="16"/>
@@ -1780,7 +1852,10 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="appleMusicLanguageField" destination="AMG-Tf-N01" id="AMG-Ot-U01"/>
+                        <outlet property="appleMusicMediaUserTokenField" destination="AMT-Tf-N01" id="AMT-Ot-U01"/>
                         <outlet property="appleMusicNameRecoveryButton" destination="ANR-Bt-N01" id="ANR-Ot-U01"/>
+                        <outlet property="appleMusicStorefrontField" destination="AMS-Tf-N01" id="AMS-Ot-U01"/>
                         <outlet property="artworkSimilarityBoostButton" destination="ART-Bt-N01" id="ART-Ot-U01"/>
                         <outlet property="enableTouchBarLyricsButton" destination="D7U-qs-Keb" id="k7p-hg-kzy"/>
                         <outlet property="musixmatchTokenField" destination="PeC-aV-j5M" id="SSi-r8-o1g"/>

--- a/LyricsX/Supporting Files/Base.lproj/Preferences.storyboard
+++ b/LyricsX/Supporting Files/Base.lproj/Preferences.storyboard
@@ -1497,11 +1497,11 @@
             <objects>
                 <viewController title="Lab" id="JPs-hn-m7d" customClass="PreferenceLabViewController" customModule="LyricsX" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="m1c-jC-l4b">
-                        <rect key="frame" x="0.0" y="0.0" width="615" height="611"/>
+                        <rect key="frame" x="0.0" y="0.0" width="615" height="725"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <gridView xPlacement="leading" yPlacement="fill" rowAlignment="none" rowSpacing="8" columnSpacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="jUN-mS-kOf">
-                                <rect key="frame" x="75" y="20" width="520" height="571"/>
+                                <rect key="frame" x="75" y="20" width="520" height="685"/>
                                 <rows>
                                     <gridRow yPlacement="fill" topPadding="5" id="6bF-ha-C1x"/>
                                     <gridRow yPlacement="fill" topPadding="5" id="HwQ-Go-InK"/>

--- a/LyricsX/Supporting Files/mul.lproj/Preferences.xcstrings
+++ b/LyricsX/Supporting Files/mul.lproj/Preferences.xcstrings
@@ -2503,6 +2503,30 @@
         }
       }
     },
+    "AMG-Cl-L01.title" : {
+      "comment" : "Class = \"NSTextFieldCell\"; title = \"Lyrics Language:\"; ObjectID = \"AMG-Cl-L01\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Lyrics Language:"
+          }
+        }
+      }
+    },
+    "AMG-Cl-N01.placeholderString" : {
+      "comment" : "Class = \"NSTextFieldCell\"; placeholderString = \"System default (e.g. zh-Hans, ja-JP)\"; ObjectID = \"AMG-Cl-N01\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "System default (e.g. zh-Hans, ja-JP)"
+          }
+        }
+      }
+    },
     "AML-Cl-001.title" : {
       "comment" : "Class = \"NSButtonCell\"; title = \"Use Apple Music-style lyrics window\"; ObjectID = \"AML-Cl-001\";",
       "extractionState" : "extracted_with_value",
@@ -2607,6 +2631,54 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用 Apple Music 風格的歌詞視窗"
+          }
+        }
+      }
+    },
+    "AMS-Cl-L01.title" : {
+      "comment" : "Class = \"NSTextFieldCell\"; title = \"Storefront:\"; ObjectID = \"AMS-Cl-L01\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Storefront:"
+          }
+        }
+      }
+    },
+    "AMS-Cl-N01.placeholderString" : {
+      "comment" : "Class = \"NSTextFieldCell\"; placeholderString = \"Auto-detect (e.g. cn, us, jp)\"; ObjectID = \"AMS-Cl-N01\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Auto-detect (e.g. cn, us, jp)"
+          }
+        }
+      }
+    },
+    "AMT-Cl-L01.title" : {
+      "comment" : "Class = \"NSTextFieldCell\"; title = \"Apple Music Token:\"; ObjectID = \"AMT-Cl-L01\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Apple Music Token:"
+          }
+        }
+      }
+    },
+    "AMT-Cl-N01.placeholderString" : {
+      "comment" : "Class = \"NSTextFieldCell\"; placeholderString = \"Paste media-user-token from music.apple.com\"; ObjectID = \"AMT-Cl-N01\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Paste media-user-token from music.apple.com"
           }
         }
       }
@@ -3621,6 +3693,36 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "延遲顯示歌詞："
+          }
+        }
+      }
+    },
+    "bta-bC-005.title" : {
+      "comment" : "Class = \"NSButtonCell\"; title = \"Receive beta updates\"; ObjectID = \"bta-bC-005\";",
+      "extractionState" : "manual",
+      "localizations" : {
+        "base" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Receive beta updates"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Receive beta updates"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接收 Beta 版更新"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接收 Beta 版更新"
           }
         }
       }
@@ -9721,120 +9823,6 @@
         }
       }
     },
-    "source-Kana-Cell.title" : {
-      "comment" : "Class = \"NSButtonCell\"; title = \"Use source-provided kana when available\"; ObjectID = \"source-Kana-Cell\";",
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "استخدام الكانا المقدَّمة من المصدر عند توفرها"
-          }
-        },
-        "base" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use source-provided kana when available"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vom Anbieter bereitgestellte Kana verwenden, sofern verfügbar"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Use source-provided kana when available"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usar los kana proporcionados por la fuente cuando estén disponibles"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "استفاده از کانای ارائه‌شده توسط منبع در صورت موجود بودن"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utiliser les kana fournis par la source lorsqu’ils sont disponibles"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gunakan kana yang disediakan sumber jika tersedia"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usa i kana forniti dalla fonte quando disponibili"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取得元が提供するかなを優先的に使用する"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "출처에서 제공하는 가나를 가능할 때 사용"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Door bron aangeleverde kana gebruiken indien beschikbaar"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Używaj kana dostarczonych przez źródło, jeśli są dostępne"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usar os kana fornecidos pela fonte quando disponíveis"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Использовать кану из источника, если она доступна"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Використовувати кану з джерела, якщо доступна"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "优先使用歌词源提供的假名"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "優先使用歌詞源提供的假名"
-          }
-        }
-      }
-    },
     "new-Romajin-Cell.title" : {
       "comment" : "Class = \"NSButtonCell\"; title = \"Automatically generate romajin for Japanese lyrics\"; ObjectID = \"new-Romajin-Cell\";",
       "extractionState" : "extracted_with_value",
@@ -11797,6 +11785,120 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "全體歌詞時間軸偏移 (ms)："
+          }
+        }
+      }
+    },
+    "source-Kana-Cell.title" : {
+      "comment" : "Class = \"NSButtonCell\"; title = \"Use source-provided kana when available\"; ObjectID = \"source-Kana-Cell\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "استخدام الكانا المقدَّمة من المصدر عند توفرها"
+          }
+        },
+        "base" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use source-provided kana when available"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vom Anbieter bereitgestellte Kana verwenden, sofern verfügbar"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use source-provided kana when available"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usar los kana proporcionados por la fuente cuando estén disponibles"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "استفاده از کانای ارائه‌شده توسط منبع در صورت موجود بودن"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utiliser les kana fournis par la source lorsqu’ils sont disponibles"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gunakan kana yang disediakan sumber jika tersedia"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usa i kana forniti dalla fonte quando disponibili"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取得元が提供するかなを優先的に使用する"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "출처에서 제공하는 가나를 가능할 때 사용"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Door bron aangeleverde kana gebruiken indien beschikbaar"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Używaj kana dostarczonych przez źródło, jeśli są dostępne"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usar os kana fornecidos pela fonte quando disponíveis"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Использовать кану из источника, если она доступна"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Використовувати кану з джерела, якщо доступна"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "优先使用歌词源提供的假名"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "優先使用歌詞源提供的假名"
           }
         }
       }
@@ -15558,36 +15660,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "全體歌詞時間軸偏移 (ms)："
-          }
-        }
-      }
-    },
-    "bta-bC-005.title" : {
-      "comment" : "Class = \"NSButtonCell\"; title = \"Receive beta updates\"; ObjectID = \"bta-bC-005\";",
-      "extractionState" : "manual",
-      "localizations" : {
-        "base" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Receive beta updates"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Receive beta updates"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "接收 Beta 版更新"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "接收 Beta 版更新"
           }
         }
       }

--- a/LyricsX/TouchBar/TouchBarLyricsItem.swift
+++ b/LyricsX/TouchBar/TouchBarLyricsItem.swift
@@ -52,7 +52,10 @@ class TouchBarLyricsItem: NSCustomTouchBarItem {
         DispatchQueue.main.async {
             self.lyricsTextField.stringValue = lyricsContent
             if let timetag = line.attachments.timetag {
-                let progress = timetag.tags.map { ($0.time + line.position - timeDelay - position, $0.index) }
+                var progress = timetag.tags.map { ($0.time + line.position - timeDelay - position, $0.index) }
+                if let duration = timetag.duration, duration > 0 {
+                    progress.append((duration + line.position - timeDelay - position, line.content.count))
+                }
                 self.lyricsTextField.setProgressAnimation(color: self.progressColor, progress: progress)
                 if !playbackState.isPlaying {
                     self.lyricsTextField.pauseProgressAnimation()

--- a/LyricsX/Utility/Global.swift
+++ b/LyricsX/Utility/Global.swift
@@ -201,6 +201,23 @@ extension UserDefaults.DefaultsKeys {
     // Apple Music Route B — recover a track's native-script name via the
     // Apple Music catalog so the third-party providers can match it.
     static let appleMusicNameRecoveryEnabled = Key<Bool>("AppleMusicNameRecoveryEnabled")
+
+    // Apple Music Route A — official syllable-lyrics, fetched via the
+    // amp-api `music.api.music()` from a `WKWebView` signed in with the
+    // user's `media-user-token`. The token is pasted by the user (it
+    // cannot be obtained programmatically without MusicKit Capability +
+    // user consent, which Route A's endpoint does not honor).
+    //
+    // When empty, the Apple Music provider is not registered.
+    static let appleMusicMediaUserToken = Key<String?>("AppleMusicMediaUserToken")
+
+    // Storefront override (2-letter country code, e.g. "cn", "us", "jp").
+    // When empty, auto-detected via `/v1/me/storefront`.
+    static let appleMusicStorefront = Key<String?>("AppleMusicStorefront")
+
+    // Language override for TTML translations (e.g. "zh-Hans", "ja-JP").
+    // When empty, uses `Locale.preferredLanguages[0]`.
+    static let appleMusicLanguage = Key<String?>("AppleMusicLanguage")
 }
 
 // MARK: - Lyrics Priority

--- a/LyricsX/View/DragNDropView.swift
+++ b/LyricsX/View/DragNDropView.swift
@@ -1,7 +1,7 @@
 import AppKit
 
 protocol DragNDropDelegate: AnyObject {
-    func dragFinished(content: String)
+    func dragFinished(content: String, filePath: String?)
 }
 
 class DragNDropView: NSView {
@@ -25,7 +25,7 @@ class DragNDropView: NSView {
 
         if pboard.types?.contains(.string) == true,
            let str = pboard.string(forType: .string) {
-            dragDelegate?.dragFinished(content: str)
+            dragDelegate?.dragFinished(content: str, filePath: nil)
             return true
         }
 
@@ -34,7 +34,7 @@ class DragNDropView: NSView {
                let files = pboard.propertyList(forType: .fileNames) as? [Any],
                let path = files.first as? String {
                 let str = try String(contentsOf: URL(fileURLWithPath: path))
-                dragDelegate?.dragFinished(content: str)
+                dragDelegate?.dragFinished(content: str, filePath: path)
                 return true
             } else {
                 let errorInfo = [


### PR DESCRIPTION
## Summary

Wires the Apple Music official syllable-lyrics provider added in MxIris-LyricsX-Project/LyricsKit#6 into LyricsX, plus a couple of related fixes.

- **AppController**: `updateLyricsManager()` becomes async; at startup and on token change it primes `AppleMusicSession.shared` with the user's saved token + overrides, then mounts `LyricsProviders.Service.appleMusic` only if the session probe (`/v1/me/storefront`) succeeds — without that gate, every fetch with a stale token would 401 and pollute the result stream.
- **Lab preference pane**: three new fields — `Apple Music Token`, `Storefront`, `Lyrics Language`. Token paste reconfigures the session and rebuilds the lyrics manager. Pane height grown 611 → 725 pt so the new rows aren't clipped.
- **TTML drag-and-drop import**: `AppController.importLyrics(_:filePath:)` auto-detects TTML by `.ttml` extension or `<tt` root element; `DragNDropDelegate.dragFinished` threads the source path through `LyricsHUDViewController` so the extension check works for dropped files.
- **Three new `Defaults` keys**: `AppleMusicMediaUserToken`, `AppleMusicStorefront`, `AppleMusicLanguage`.
- **Karaoke / Touch Bar fix** (separate `fix:` commit): append `(timetag.duration, line.content.count)` keyframe so the last word of a syllable-timed line fills progressively instead of getting stuck at its begin tag. Surfaced by Apple Music's TTML but affects any timetag with a `duration`.

Route B (existing MusicKit-based `AppleMusicNameRecoveryPlugin`) is **untouched** — Route A is additive.

## Depends on

- MxIris-LyricsX-Project/LyricsKit#6 — must be merged + tagged (or `LyricsXPackage/Package.swift` switched to a branch ref) before CI on this PR can resolve the new `LyricsKitAppleMusic` products.

## Test plan

- [x] xcodebuild -workspace … -scheme LyricsX build clean (0 errors)
- [x] Smoke test: paste real media-user-token into Lab → fetch syllable TTML for 周杰倫《晴天》 → parser yields 42 lines with timing + Simplified Chinese translations
- [x] Lab pane renders correctly — token row visible without clipping
- [ ] Reviewer: confirm Defaults key naming matches existing conventions
- [ ] Reviewer: spot-check storyboard XML diff — added via hand-edit (no IB round-trip yet)
- [ ] Manual: play an Apple Music track, observe Route A provider mounts only when token is present and session.isAuthorized() is true